### PR TITLE
Contextual Leadership Blocks

### DIFF
--- a/packages/common/browser/index.js
+++ b/packages/common/browser/index.js
@@ -1,8 +1,10 @@
 import ContactUsForm from './contact-us-form.vue';
 import LeadersItem from '../leaders/browser/item.vue';
+import LeadersItemStatic from '../leaders/browser/item-static.vue';
 
 export default (Browser) => {
   // @todo this should be removed once contact us is moved to core.
   Browser.registerComponent('CommonContactUsForm', ContactUsForm);
   Browser.registerComponent('CommonLeadersItem', LeadersItem);
+  Browser.registerComponent('CommonLeadersItemStatic', LeadersItemStatic);
 };

--- a/packages/common/leaders/browser/item-static.vue
+++ b/packages/common/leaders/browser/item-static.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="text-left">
+    <p class="mb-1 ml-3 font-weight-bold">{{ name }}:</p>
+    <ul class="leaders__item-list">
+      <li v-if="loading" class="leaders__item-list-item">
+        Loading...
+      </li>
+      <li v-else-if="error" class="leaders__item-list-item">
+        Unable to load items: {{ error.message }}
+      </li>
+      <li v-else-if="!items.length" class="leaders__item-list-item">
+        No results found.
+      </li>
+      <li
+        v-for="content in items"
+        v-else
+        :key="content.id"
+        class="leaders__item-list-item"
+      >
+        <a :href="content.siteContext.path" :title="content.name">
+          {{ content.name }}
+          <IconYoutube v-if="content.showIcon" />
+        </a>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import { getAsArray } from '@base-cms/object-path';
+import IconYoutube from '@base-cms/marko-web-icons/browser/youtube.vue';
+
+export default {
+  components: {
+    IconYoutube,
+  },
+  props: {
+    id: {
+      type: Number,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    limit: {
+      type: Number,
+      default: 20,
+    },
+  },
+  data() {
+    return {
+      loading: false,
+      error: null,
+      items: [],
+      expanded: false,
+      promise: null,
+    };
+  },
+  async mounted() {
+    const { limit, id: sectionId } = this;
+    try {
+      this.loading = true;
+      this.error = null;
+      const res = await fetch('/__leaders-content', {
+        method: 'post',
+        body: JSON.stringify({ limit, sectionId }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!res.ok) {
+        this.promise = null;
+        throw new Error(res.statusText);
+      }
+      const items = await res.json();
+      this.items = items.map((item) => {
+        const showIcon = getAsArray(item, 'socialLinks').some(({ provider }) => provider === 'youtube');
+        return { ...item, showIcon };
+      });
+    } catch (e) {
+      this.error = e;
+    } finally {
+      this.loading = false;
+    }
+  },
+};
+</script>

--- a/packages/common/leaders/components/contextual.marko
+++ b/packages/common/leaders/components/contextual.marko
@@ -1,0 +1,36 @@
+import { getAsArray } from "@base-cms/object-path";
+import queryFragment from "../graphql/fragments/sections";
+
+$ const {
+  sectionAlias,
+  logoSrc: src,
+  logoAlt: alt,
+} = input;
+
+$ const taxonomyIds = getAsArray(input, 'taxonomyIds');
+
+<if(!taxonomyIds.length)>
+  <leaders-block-index section-alias=sectionAlias logo-src=src logo-alt=alt columns=1 />
+</if>
+<else>
+  <marko-web-query|{ nodes }| name="website-sections" params={ taxonomyIds, queryFragment }>
+    $ const sections = nodes.filter(node => getAsArray(node, 'hierarchy').some(({ alias }) => alias === sectionAlias));
+    <if(sections.length)>
+      <marko-web-node-list>
+        <@header modifiers=["centered"]>
+          <if(src)>
+            <img src=src alt=alt class="leaders__logo" />
+          </if>
+        </@header>
+        <@nodes nodes=sections>
+          <for|node| of=sections>
+            <marko-web-browser-component name="CommonLeadersItemStatic" props={ id: node.id, name: node.name } />
+          </for>
+        </@nodes>
+      </marko-web-node-list>
+    </if>
+    <else>
+      <leaders-block-index section-alias=sectionAlias logo-src=src logo-alt=alt columns=1 />
+    </else>
+  </marko-web-query>
+</else>

--- a/packages/common/leaders/components/contextual.marko
+++ b/packages/common/leaders/components/contextual.marko
@@ -7,14 +7,14 @@ $ const {
   logoAlt: alt,
 } = input;
 
-$ const taxonomyIds = getAsArray(input, 'taxonomyIds');
+$ const taxonomyIds = getAsArray(input, "taxonomyIds");
 
 <if(!taxonomyIds.length)>
   <leaders-block-index section-alias=sectionAlias logo-src=src logo-alt=alt columns=1 />
 </if>
 <else>
   <marko-web-query|{ nodes }| name="website-sections" params={ taxonomyIds, queryFragment }>
-    $ const sections = nodes.filter(node => getAsArray(node, 'hierarchy').some(({ alias }) => alias === sectionAlias));
+    $ const sections = nodes.filter(node => getAsArray(node, "hierarchy").some(({ alias }) => alias === sectionAlias));
     <if(sections.length)>
       <marko-web-node-list>
         <@header modifiers=["centered"]>

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -10,7 +10,7 @@ $ const {
 } = input;
 
 <marko-web-query|{ node: leaders }| name="website-section" params={ alias, queryFragment }>
-  $ const nodes = getAsArray(leaders, 'children.edges').map(({ node }) => node);
+  $ const nodes = getAsArray(leaders, "children.edges").map(({ node }) => node);
   <marko-web-node-list>
     <@header modifiers=["centered"]>
       <if(src)>
@@ -21,7 +21,7 @@ $ const {
       <@body modifiers=["centered"] value=bodyText />
     </if>
     <@nodes nodes=nodes>
-      $ const colClass = columns === 2 ? 'col-lg-6 mb-block list-unstyled' : 'col list-unstyled';
+      $ const colClass = columns === 2 ? "col-lg-6 mb-block list-unstyled" : "col list-unstyled";
       $ const mid = Math.floor(nodes.length / 2)
       $ const groups = columns == 2 ? [
         [...nodes.slice(0, mid)],
@@ -31,7 +31,7 @@ $ const {
         <for|group| of=groups>
           <ul class=colClass>
             <for|node| of=group>
-              $ const children = getAsArray(node, 'children.edges').map(({ node: item }) => item);
+              $ const children = getAsArray(node, "children.edges").map(({ node: item }) => item);
               <if(children.length)>
                 <li class="leaders__category">
                   <label class="leaders__category-label">${node.name}</label>

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -13,7 +13,7 @@ $ const {
   <marko-web-node-list>
     <@header modifiers=["centered"]>
       <if(src)>
-        <img src=src alt=alt />
+        <img src=src alt=alt class="leaders__logo" />
       </if>
     </@header>
     <if(bodyText)>

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -5,6 +5,7 @@ $ const {
   sectionAlias: alias,
   logoSrc: src,
   logoAlt: alt,
+  bodyText,
 } = input;
 
 <marko-web-query|{ node: leaders }| name="website-section" params={ alias, queryFragment }>
@@ -15,9 +16,9 @@ $ const {
         <img src=src alt=alt />
       </if>
     </@header>
-    <@body modifiers=["centered"]>
-      Browse these leading suppliers:
-    </@body>
+    <if(bodyText)>
+      <@body modifiers=["centered"] value=bodyText />
+    </if>
     <@nodes nodes=nodes>
       $ const mid = Math.floor(nodes.length / 2)
       $ const groups = [

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -9,7 +9,7 @@ $ const {
 
 <marko-web-query|{ node: leaders }| name="website-section" params={ alias, queryFragment }>
   $ const nodes = getAsArray(leaders, 'children.edges').map(({ node }) => node);
-  <marko-web-node-list modifiers=["nodes-flex-row"]>
+  <marko-web-node-list>
     <@header modifiers=["centered"]>
       <if(src)>
         <img src=src alt=alt />

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -6,6 +6,7 @@ $ const {
   logoSrc: src,
   logoAlt: alt,
   bodyText,
+  columns,
 } = input;
 
 <marko-web-query|{ node: leaders }| name="website-section" params={ alias, queryFragment }>
@@ -20,14 +21,15 @@ $ const {
       <@body modifiers=["centered"] value=bodyText />
     </if>
     <@nodes nodes=nodes>
+      $ const colClass = columns === 2 ? 'col-lg-6 mb-block list-unstyled' : 'col list-unstyled';
       $ const mid = Math.floor(nodes.length / 2)
-      $ const groups = [
+      $ const groups = columns == 2 ? [
         [...nodes.slice(0, mid)],
         [...nodes.slice(mid, nodes.length)],
-      ];
+      ] : [nodes];
       <div class="row">
         <for|group| of=groups>
-          <ul class="col-lg-6 mb-block list-unstyled">
+          <ul class=colClass>
             <for|node| of=group>
               $ const children = getAsArray(node, 'children.edges').map(({ node: item }) => item);
               <if(children.length)>

--- a/packages/common/leaders/components/marko.json
+++ b/packages/common/leaders/components/marko.json
@@ -4,7 +4,8 @@
       "template": "./index.marko",
       "@section-alias": "string",
       "@logo-src": "string",
-      "@logo-alt": "string"
+      "@logo-alt": "string",
+      "@body-text": "string"
     }
   }
 }

--- a/packages/common/leaders/components/marko.json
+++ b/packages/common/leaders/components/marko.json
@@ -10,6 +10,13 @@
         "type": "number",
         "default-value": 2
       }
+    },
+    "leaders-block-contextual": {
+      "template": "./contextual.marko",
+      "@section-alias": "string",
+      "@logo-src": "string",
+      "@logo-alt": "string",
+      "@taxonomy-ids": "array"
     }
   }
 }

--- a/packages/common/leaders/components/marko.json
+++ b/packages/common/leaders/components/marko.json
@@ -5,7 +5,11 @@
       "@section-alias": "string",
       "@logo-src": "string",
       "@logo-alt": "string",
-      "@body-text": "string"
+      "@body-text": "string",
+      "@columns": {
+        "type": "number",
+        "default-value": 2
+      }
     }
   }
 }

--- a/packages/common/leaders/graphql/fragments/sections.js
+++ b/packages/common/leaders/graphql/fragments/sections.js
@@ -1,0 +1,12 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment LeadersSectionsFragment on WebsiteSection {
+  id
+  name
+  hierarchy{
+    id
+    alias
+  }
+}
+`;

--- a/packages/common/leaders/graphql/fragments/sections.js
+++ b/packages/common/leaders/graphql/fragments/sections.js
@@ -4,7 +4,7 @@ module.exports = gql`
 fragment LeadersSectionsFragment on WebsiteSection {
   id
   name
-  hierarchy{
+  hierarchy {
     id
     alias
   }

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -1,4 +1,7 @@
 .leaders {
+  &__logo {
+    max-width: 100%;
+  }
   &__item {
     .btn-link:hover,
     .btn-link:active,

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -3,6 +3,7 @@
     max-width: 100%;
   }
   &__item {
+    text-align: left;
     .btn-link:hover,
     .btn-link:active,
     .btn-link:focus {

--- a/sites/automationworld/server/graphql/fragments/content-page.js
+++ b/sites/automationworld/server/graphql/fragments/content-page.js
@@ -14,6 +14,14 @@ fragment ContentPageFragment on Content {
       path
     }
   }
+  taxonomy {
+    edges {
+      node {
+        id
+        type
+      }
+    }
+  }
   primarySection {
     id
     name

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -1,5 +1,5 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
-import { getAsObject, get } from "@base-cms/object-path";
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -109,6 +109,12 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <div id="article-leaders-vote-btn" />
 
               <!-- Leaders block here -->
+              <leaders-block-contextual
+                section-alias="leaders"
+                logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/aw.png"
+                logo-alt="Leaders in Automation"
+                taxonomy-ids=getAsArray(content, 'taxonomy.edges').map(({ node }) => node.id)
+              />
 
               <!-- Div for Audience -->
               <div id="article-01-right" />

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -113,7 +113,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 section-alias="leaders"
                 logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/aw.png"
                 logo-alt="Leaders in Automation"
-                taxonomy-ids=getAsArray(content, 'taxonomy.edges').map(({ node }) => node.id)
+                taxonomy-ids=getAsArray(content, "taxonomy.edges").map(({ node }) => node.id)
               />
 
               <!-- Div for Audience -->

--- a/sites/automationworld/server/templates/index.marko
+++ b/sites/automationworld/server/templates/index.marko
@@ -115,6 +115,7 @@ $ const { id, alias, name, pageNode } = data;
           section-alias="leaders"
           logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/aw.png"
           logo-alt="Leaders in Automation"
+          body-text="Browse these leading suppliers:"
         />
       </div>
       <div class="col-lg-4 mb-block page-rail">

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -113,7 +113,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 section-alias="leaders"
                 logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/hcp.png"
                 logo-alt="Premiere Suppliers"
-                taxonomy-ids=getAsArray(content, 'taxonomy.edges').map(({ node }) => node.id)
+                taxonomy-ids=getAsArray(content, "taxonomy.edges").map(({ node }) => node.id)
               />
 
               <!-- Div for Audience -->

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -1,5 +1,5 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
-import { getAsObject, get } from "@base-cms/object-path";
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -109,6 +109,12 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <div id="article-leaders-vote-btn" />
 
               <!-- Leaders block here -->
+              <leaders-block-contextual
+                section-alias="leaders"
+                logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/hcp.png"
+                logo-alt="Premiere Suppliers"
+                taxonomy-ids=getAsArray(content, 'taxonomy.edges').map(({ node }) => node.id)
+              />
 
               <!-- Div for Audience -->
               <div id="article-01-right" />

--- a/sites/healthcarepackaging/server/templates/index.marko
+++ b/sites/healthcarepackaging/server/templates/index.marko
@@ -40,6 +40,7 @@ $ const { id, alias, name, pageNode } = data;
           section-alias="leaders"
           logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/hcp.png"
           logo-alt="Premiere Suppliers"
+          body-text="Browse these leading suppliers:"
         />
       </div>
       <div class="col-lg-4 mb-block page-rail">

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -1,5 +1,5 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
-import { getAsObject, get } from "@base-cms/object-path";
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -109,6 +109,12 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <div id="article-leaders-vote-btn" />
 
               <!-- Leaders block here -->
+              <leaders-block-contextual
+                section-alias="leaders"
+                logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/oem.png"
+                logo-alt="OEM Tech Trendsetters"
+                taxonomy-ids=getAsArray(content, 'taxonomy.edges').map(({ node }) => node.id)
+              />
 
               <!-- Div for Audience -->
               <div id="article-01-right" />

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -113,7 +113,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 section-alias="leaders"
                 logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/oem.png"
                 logo-alt="OEM Tech Trendsetters"
-                taxonomy-ids=getAsArray(content, 'taxonomy.edges').map(({ node }) => node.id)
+                taxonomy-ids=getAsArray(content, "taxonomy.edges").map(({ node }) => node.id)
               />
 
               <!-- Div for Audience -->

--- a/sites/oemmagazine/server/templates/index.marko
+++ b/sites/oemmagazine/server/templates/index.marko
@@ -40,6 +40,7 @@ $ const { id, alias, name, pageNode } = data;
           section-alias="leaders"
           logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/oem.png"
           logo-alt="OEM Tech Trendsetters"
+          body-text="Browse these leading suppliers:"
         />
       </div>
       <div class="col-lg-4 mb-block page-rail">

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -113,7 +113,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 section-alias="leaders"
                 logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/pw.png"
                 logo-alt="Leaders in Packaging"
-                taxonomy-ids=getAsArray(content, 'taxonomy.edges').map(({ node }) => node.id)
+                taxonomy-ids=getAsArray(content, "taxonomy.edges").map(({ node }) => node.id)
               />
 
               <!-- Div for Audience -->

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -1,5 +1,5 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
-import { getAsObject, get } from "@base-cms/object-path";
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -109,6 +109,12 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <div id="article-leaders-vote-btn" />
 
               <!-- Leaders block here -->
+              <leaders-block-contextual
+                section-alias="leaders"
+                logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/pw.png"
+                logo-alt="Leaders in Packaging"
+                taxonomy-ids=getAsArray(content, 'taxonomy.edges').map(({ node }) => node.id)
+              />
 
               <!-- Div for Audience -->
               <div id="article-01-right" />

--- a/sites/packworld/server/templates/index.marko
+++ b/sites/packworld/server/templates/index.marko
@@ -40,6 +40,7 @@ $ const { id, alias, name, pageNode } = data;
           section-alias="leaders"
           logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/pw.png"
           logo-alt="Leaders in Packaging"
+          body-text="Browse these leading suppliers:"
         />
       </div>
       <div class="col-lg-4 mb-block page-rail">

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -1,5 +1,5 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
-import { getAsObject, get } from "@base-cms/object-path";
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -109,6 +109,12 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <div id="article-leaders-vote-btn" />
 
               <!-- Leaders block here -->
+              <leaders-block-contextual
+                section-alias="leaders"
+                logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/pfw.png"
+                logo-alt="Leaders in Processing"
+                taxonomy-ids=getAsArray(content, 'taxonomy.edges').map(({ node }) => node.id)
+              />
 
               <!-- Div for Audience -->
               <div id="article-01-right" />

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -113,7 +113,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 section-alias="leaders"
                 logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/pfw.png"
                 logo-alt="Leaders in Processing"
-                taxonomy-ids=getAsArray(content, 'taxonomy.edges').map(({ node }) => node.id)
+                taxonomy-ids=getAsArray(content, "taxonomy.edges").map(({ node }) => node.id)
               />
 
               <!-- Div for Audience -->

--- a/sites/profoodworld/server/templates/index.marko
+++ b/sites/profoodworld/server/templates/index.marko
@@ -40,6 +40,7 @@ $ const { id, alias, name, pageNode } = data;
           section-alias="leaders"
           logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/pfw.png"
           logo-alt="Leaders in Processing"
+          body-text="Browse these leading suppliers:"
         />
       </div>
       <div class="col-lg-4 mb-block page-rail">


### PR DESCRIPTION
This PR adds the contextual leadership block on PMMI content pages. This block will query for sections where `relatedTaxonomy` in `content.taxonomy` ids. If found, the list will be filtered by the passed root `sectionAlias` to ensure that only 2019 Leaders sections are returned.

When one or more contextual sections are found, the block displays their leadership information with the categories expanded and not contractable:
![aw-with-context](https://user-images.githubusercontent.com/1778222/67251722-9282cb00-f435-11e9-9dcb-024509c50656.jpg)

When no contextual sections are found, the block displays a single-column version of the homepage component (expandable, collapsed by default):
![pfw-no-context](https://user-images.githubusercontent.com/1778222/67251724-99114280-f435-11e9-895c-15b28857aca9.jpg)