### PR TITLE
Add custom webinar layout to all PMMI sites

### DIFF
--- a/sites/automationworld/server/routes/content.js
+++ b/sites/automationworld/server/routes/content.js
@@ -1,8 +1,13 @@
 const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
+const webinar = require('../templates/content/webinar');
 const queryFragment = require('../graphql/fragments/content-page');
 
 module.exports = (app) => {
+  app.get('/*?webinar/:id(\\d{8})*', withContent({
+    template: webinar,
+    queryFragment,
+  }));
   app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,

--- a/sites/automationworld/server/templates/content/webinar.marko
+++ b/sites/automationworld/server/templates/content/webinar.marko
@@ -1,0 +1,55 @@
+import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+import GAM from "../../../config/gam";
+
+$ const { site } = out.global;
+$ const { id, type, pageNode } = data;
+
+$ const displayPrimaryImage = true;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      $ const aliases = hierarchyAliases(content.primarySection);
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=content.primarySection />
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+              <default-theme-page-dates|{ blockName }|>
+                <marko-web-content-starts block-name=blockName obj=content />
+              </default-theme-page-dates>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }| class="col-lg-8 mb-3 mb-lg-0">
+
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+
+            </default-theme-page-contents>
+
+            <aside class="col-lg-4 page-rail">
+
+            </aside>
+          </div>
+
+        </@section>
+      </marko-web-page-wrapper>
+
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>

--- a/sites/healthcarepackaging/server/routes/content.js
+++ b/sites/healthcarepackaging/server/routes/content.js
@@ -1,8 +1,13 @@
 const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
+const webinar = require('../templates/content/webinar');
 const queryFragment = require('../graphql/fragments/content-page');
 
 module.exports = (app) => {
+  app.get('/*?webinar/:id(\\d{8})*', withContent({
+    template: webinar,
+    queryFragment,
+  }));
   app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,

--- a/sites/healthcarepackaging/server/templates/content/webinar.marko
+++ b/sites/healthcarepackaging/server/templates/content/webinar.marko
@@ -1,0 +1,55 @@
+import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+import GAM from "../../../config/gam";
+
+$ const { site } = out.global;
+$ const { id, type, pageNode } = data;
+
+$ const displayPrimaryImage = true;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      $ const aliases = hierarchyAliases(content.primarySection);
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=content.primarySection />
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+              <default-theme-page-dates|{ blockName }|>
+                <marko-web-content-starts block-name=blockName obj=content />
+              </default-theme-page-dates>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }| class="col-lg-8 mb-3 mb-lg-0">
+
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+
+            </default-theme-page-contents>
+
+            <aside class="col-lg-4 page-rail">
+
+            </aside>
+          </div>
+
+        </@section>
+      </marko-web-page-wrapper>
+
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>

--- a/sites/oemmagazine/server/routes/content.js
+++ b/sites/oemmagazine/server/routes/content.js
@@ -1,8 +1,13 @@
 const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
+const webinar = require('../templates/content/webinar');
 const queryFragment = require('../graphql/fragments/content-page');
 
 module.exports = (app) => {
+  app.get('/*?webinar/:id(\\d{8})*', withContent({
+    template: webinar,
+    queryFragment,
+  }));
   app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,

--- a/sites/oemmagazine/server/templates/content/webinar.marko
+++ b/sites/oemmagazine/server/templates/content/webinar.marko
@@ -1,0 +1,55 @@
+import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+import GAM from "../../../config/gam";
+
+$ const { site } = out.global;
+$ const { id, type, pageNode } = data;
+
+$ const displayPrimaryImage = true;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      $ const aliases = hierarchyAliases(content.primarySection);
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=content.primarySection />
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+              <default-theme-page-dates|{ blockName }|>
+                <marko-web-content-starts block-name=blockName obj=content />
+              </default-theme-page-dates>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }| class="col-lg-8 mb-3 mb-lg-0">
+
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+
+            </default-theme-page-contents>
+
+            <aside class="col-lg-4 page-rail">
+
+            </aside>
+          </div>
+
+        </@section>
+      </marko-web-page-wrapper>
+
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>

--- a/sites/packworld/server/routes/content.js
+++ b/sites/packworld/server/routes/content.js
@@ -1,8 +1,13 @@
 const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
+const webinar = require('../templates/content/webinar');
 const queryFragment = require('../graphql/fragments/content-page');
 
 module.exports = (app) => {
+  app.get('/*?webinar/:id(\\d{8})*', withContent({
+    template: webinar,
+    queryFragment,
+  }));
   app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,

--- a/sites/packworld/server/templates/content/webinar.marko
+++ b/sites/packworld/server/templates/content/webinar.marko
@@ -1,0 +1,55 @@
+import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+import GAM from "../../../config/gam";
+
+$ const { site } = out.global;
+$ const { id, type, pageNode } = data;
+
+$ const displayPrimaryImage = true;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      $ const aliases = hierarchyAliases(content.primarySection);
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=content.primarySection />
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+              <default-theme-page-dates|{ blockName }|>
+                <marko-web-content-starts block-name=blockName obj=content />
+              </default-theme-page-dates>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }| class="col-lg-8 mb-3 mb-lg-0">
+
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+
+            </default-theme-page-contents>
+
+            <aside class="col-lg-4 page-rail">
+
+            </aside>
+          </div>
+
+        </@section>
+      </marko-web-page-wrapper>
+
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>

--- a/sites/profoodworld/server/routes/content.js
+++ b/sites/profoodworld/server/routes/content.js
@@ -1,8 +1,13 @@
 const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
+const webinar = require('../templates/content/webinar');
 const queryFragment = require('../graphql/fragments/content-page');
 
 module.exports = (app) => {
+  app.get('/*?webinar/:id(\\d{8})*', withContent({
+    template: webinar,
+    queryFragment,
+  }));
   app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,

--- a/sites/profoodworld/server/templates/content/webinar.marko
+++ b/sites/profoodworld/server/templates/content/webinar.marko
@@ -1,0 +1,55 @@
+import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+import GAM from "../../../config/gam";
+
+$ const { site } = out.global;
+$ const { id, type, pageNode } = data;
+
+$ const displayPrimaryImage = true;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      $ const aliases = hierarchyAliases(content.primarySection);
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=content.primarySection />
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+              <default-theme-page-dates|{ blockName }|>
+                <marko-web-content-starts block-name=blockName obj=content />
+              </default-theme-page-dates>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }| class="col-lg-8 mb-3 mb-lg-0">
+
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+
+            </default-theme-page-contents>
+
+            <aside class="col-lg-4 page-rail">
+
+            </aside>
+          </div>
+
+        </@section>
+      </marko-web-page-wrapper>
+
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>


### PR DESCRIPTION
Custom webinar layout to remove all ads, empty the right rail, and remove load more.

![aw-webinar](https://user-images.githubusercontent.com/2855198/67487381-6a60bb00-f633-11e9-9436-40587dfeac21.jpg)
