### PR TITLE
Leadership Data Cards

### DIFF
--- a/packages/common/leaders/browser/company.vue
+++ b/packages/common/leaders/browser/company.vue
@@ -2,16 +2,19 @@
   <li class="leaders__item-list-item" @mouseenter="show" @mouseleave="hide">
     <a :href="get(company, 'siteContext.path')" :title="get(company, 'name')">
       {{ get(company, 'name') }}
-      <IconYoutube v-if="company.showIcon" />
+      <IconYoutube v-if="showIcon" />
     </a>
     <DataCard
       v-if="expanded"
+      :grow="grow"
       :logoSrc="get(this.company, 'primaryImage.src')"
       :contact-src="get(this.contact, 'primaryImage.src')"
       :website="website"
       :name="get(company, 'name')"
       :product-summary="get(company, 'productSummary')"
       :promotions="promotions"
+      :youtube="get(company, 'youtube')"
+      :youtubeVideos="get(company, 'youtubeVideos')"
       :contact-name="get(contact, 'name')"
       :contact-title="get(contact, 'title')"
       :path="get(company, 'siteContext.path')"
@@ -35,6 +38,10 @@ export default {
       type: Object,
       required: true,
     },
+    grow: {
+      type: String,
+      default: 'right',
+    }
   },
   data() {
     return {
@@ -51,6 +58,9 @@ export default {
     website() {
       const url = get(this.company, 'website');
       if (url) return /^http/.test(url) ? url : `https://${url}`;
+    },
+    showIcon() {
+      return get(this.company, 'youtube.username') || get(this.company, 'youtube.channelId');
     },
   },
   methods: {

--- a/packages/common/leaders/browser/company.vue
+++ b/packages/common/leaders/browser/company.vue
@@ -1,0 +1,58 @@
+<template>
+  <li class="leaders__item-list-item">
+    <a :href="get(company, 'siteContext.path')" :title="get(company, 'name')" @mouseenter="show" @mouseleave="hide">
+      {{ get(company, 'name') }}
+      <IconYoutube v-if="company.showIcon" />
+    </a>
+  </li>
+</template>
+
+<script>
+import { getAsArray, get } from '@base-cms/object-path';
+import IconYoutube from '@base-cms/marko-web-icons/browser/youtube.vue';
+
+export default {
+  components: {
+    IconYoutube,
+  },
+  props: {
+    company: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      expanded: false,
+    };
+  },
+  computed: {
+    logoSrc() {
+      const src = get(this.company, 'primaryImage.src');
+      if (src) return src.replace(/auto=format.*$/, 'auto=format&fill-color=fff&fit=fill&h=100&pad=5&w=100');
+    },
+    contact() {
+      return getAsArray(this.company, 'publicContacts.edges').map(({ node }) => node).shift();
+    },
+    contactSrc() {
+      const src = get(this.contact, 'primaryImage.src');
+      if (src) return src.replace(/auto=format.*$/, 'auto=format&h=50&w=50');
+    },
+    website() {
+      const url = get(this.company, 'website');
+      if (url) return /^http/.test(url) ? url : `https://${url}`;
+    },
+  },
+  methods: {
+    get(object, path) {
+      return get(object, path);
+    },
+    show() {
+      this.expanded = true;
+    },
+    hide() {
+      this.expanded = false;
+    }
+  },
+};
+</script>

--- a/packages/common/leaders/browser/company.vue
+++ b/packages/common/leaders/browser/company.vue
@@ -11,6 +11,7 @@
       :website="website"
       :name="get(company, 'name')"
       :product-summary="get(company, 'productSummary')"
+      :promotions="promotions"
       :contact-name="get(contact, 'name')"
       :contact-title="get(contact, 'title')"
       :path="get(company, 'siteContext.path')"
@@ -43,6 +44,9 @@ export default {
   computed: {
     contact() {
       return getAsArray(this.company, 'publicContacts.edges').map(({ node }) => node).shift();
+    },
+    promotions() {
+      return getAsArray(this.company, 'promotions.edges').map(({ node }) => node);
     },
     website() {
       const url = get(this.company, 'website');

--- a/packages/common/leaders/browser/company.vue
+++ b/packages/common/leaders/browser/company.vue
@@ -1,18 +1,18 @@
 <template>
-  <li class="leaders__item-list-item">
-    <a :href="get(company, 'siteContext.path')" :title="get(company, 'name')" @mouseenter="show" @mouseleave="hide">
+  <li class="leaders__item-list-item" @mouseenter="show" @mouseleave="hide">
+    <a :href="get(company, 'siteContext.path')" :title="get(company, 'name')">
       {{ get(company, 'name') }}
       <IconYoutube v-if="company.showIcon" />
     </a>
     <DataCard
       v-if="expanded"
       :logoSrc="logoSrc"
-      :contactSrc="contactSrc"
+      :contact-src="contactSrc"
       :website="website"
       :name="get(company, 'name')"
-      :productSummary="get(company, 'productSummary')"
-      :contactName="get(contact, 'name')"
-      :contactTitle="get(contact, 'title')"
+      :product-summary="get(company, 'productSummary')"
+      :contact-name="get(contact, 'name')"
+      :contact-title="get(contact, 'title')"
       :path="get(company, 'siteContext.path')"
       :teaser="get(company, 'teaser')"
     />

--- a/packages/common/leaders/browser/company.vue
+++ b/packages/common/leaders/browser/company.vue
@@ -6,8 +6,8 @@
     </a>
     <DataCard
       v-if="expanded"
-      :logoSrc="logoSrc"
-      :contact-src="contactSrc"
+      :logoSrc="get(this.company, 'primaryImage.src')"
+      :contact-src="get(this.contact, 'primaryImage.src')"
       :website="website"
       :name="get(company, 'name')"
       :product-summary="get(company, 'productSummary')"
@@ -41,16 +41,8 @@ export default {
     };
   },
   computed: {
-    logoSrc() {
-      const src = get(this.company, 'primaryImage.src');
-      if (src) return src.replace(/auto=format.*$/, 'auto=format&fill-color=fff&fit=fill&h=100&pad=5&w=100');
-    },
     contact() {
       return getAsArray(this.company, 'publicContacts.edges').map(({ node }) => node).shift();
-    },
-    contactSrc() {
-      const src = get(this.contact, 'primaryImage.src');
-      if (src) return src.replace(/auto=format.*$/, 'auto=format&h=50&w=50');
     },
     website() {
       const url = get(this.company, 'website');

--- a/packages/common/leaders/browser/company.vue
+++ b/packages/common/leaders/browser/company.vue
@@ -4,16 +4,30 @@
       {{ get(company, 'name') }}
       <IconYoutube v-if="company.showIcon" />
     </a>
+    <DataCard
+      v-if="expanded"
+      :logoSrc="logoSrc"
+      :contactSrc="contactSrc"
+      :website="website"
+      :name="get(company, 'name')"
+      :productSummary="get(company, 'productSummary')"
+      :contactName="get(contact, 'name')"
+      :contactTitle="get(contact, 'title')"
+      :path="get(company, 'siteContext.path')"
+      :teaser="get(company, 'teaser')"
+    />
   </li>
 </template>
 
 <script>
 import { getAsArray, get } from '@base-cms/object-path';
 import IconYoutube from '@base-cms/marko-web-icons/browser/youtube.vue';
+import DataCard from './data-card.vue';
 
 export default {
   components: {
     IconYoutube,
+    DataCard,
   },
   props: {
     company: {

--- a/packages/common/leaders/browser/company.vue
+++ b/packages/common/leaders/browser/company.vue
@@ -7,14 +7,14 @@
     <DataCard
       v-if="expanded"
       :grow="grow"
-      :logoSrc="get(this.company, 'primaryImage.src')"
-      :contact-src="get(this.contact, 'primaryImage.src')"
+      :logo-src="get(company, 'primaryImage.src')"
+      :contact-src="get(contact, 'primaryImage.src')"
       :website="website"
       :name="get(company, 'name')"
       :product-summary="get(company, 'productSummary')"
       :promotions="promotions"
       :youtube="get(company, 'youtube')"
-      :youtubeVideos="get(company, 'youtubeVideos')"
+      :youtube-videos="get(company, 'youtubeVideos')"
       :contact-name="get(contact, 'name')"
       :contact-title="get(contact, 'title')"
       :path="get(company, 'siteContext.path')"
@@ -41,7 +41,7 @@ export default {
     grow: {
       type: String,
       default: 'right',
-    }
+    },
   },
   data() {
     return {
@@ -57,7 +57,7 @@ export default {
     },
     website() {
       const url = get(this.company, 'website');
-      if (url) return /^http/.test(url) ? url : `https://${url}`;
+      return /^http/.test(url) ? url : `https://${url}`;
     },
     showIcon() {
       return get(this.company, 'youtube.username') || get(this.company, 'youtube.channelId');
@@ -72,7 +72,7 @@ export default {
     },
     hide() {
       this.expanded = false;
-    }
+    },
   },
 };
 </script>

--- a/packages/common/leaders/browser/company.vue
+++ b/packages/common/leaders/browser/company.vue
@@ -12,9 +12,9 @@
       :website="website"
       :name="get(company, 'name')"
       :product-summary="get(company, 'productSummary')"
-      :promotions="promotions"
       :youtube="get(company, 'youtube')"
-      :youtube-videos="get(company, 'youtubeVideos')"
+      :promotions="promotions"
+      :videos="videos"
       :contact-name="get(contact, 'name')"
       :contact-title="get(contact, 'title')"
       :path="get(company, 'siteContext.path')"
@@ -54,6 +54,9 @@ export default {
     },
     promotions() {
       return getAsArray(this.company, 'promotions.edges').map(({ node }) => node);
+    },
+    videos() {
+      return getAsArray(this.company, 'videos.edges').map(({ node }) => node);
     },
     website() {
       const url = get(this.company, 'website');

--- a/packages/common/leaders/browser/data-card-content.vue
+++ b/packages/common/leaders/browser/data-card-content.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="ldc-right col-lg-8">
+    <div v-if="promotions.length" class="row">
+      <div class="col">
+        <PromotionList :promotions="promotions" :path="path" :name="name" />
+      </div>
+    </div>
+    <hr v-if="videos.length">
+    <div v-if="videos.length" class="row">
+      <div class="col">
+        <VideoList :videos="videos" :path="videosPath" :name="name" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { get, getAsArray } from '@base-cms/object-path';
+
+import PromotionList from './promotion-list.vue';
+import VideoList from './video-list.vue';
+
+export default {
+  components: {
+    PromotionList,
+    VideoList,
+  },
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+    path: {
+      type: String,
+      required: true,
+    },
+    promotions: {
+      type: Array,
+    },
+    youtube: {
+      type: Object,
+    },
+    youtubeVideos: {
+      type: Object,
+    },
+  },
+  data() {
+    return {};
+  },
+  computed: {
+    videos() {
+      const videos = getAsArray(this.youtubeVideos, 'items');
+      return videos.map((video) => {
+        const id = get(video, 'snippet.resourceId.videoId');
+        const linkUrl = `https://youtu.be/${id}`;
+        return {
+          linkText: get(video, 'snippet.title'),
+          linkUrl,
+          imageSrc: get(video, 'snippet.thumbnails.default.url'),
+        }
+      })
+    },
+    videosPath() {
+      const username = get(this.youtube, 'username');
+      if (username) return `https://youtube.com/user/${username}`;
+      const channelId = get(this.youtube, 'channelId');
+      if (channelId) return `https://youtube.com/channel/${channelId}`;
+      return this.path;
+    },
+  },
+  methods: {
+    get(object, path) {
+      return get(object, path);
+    },
+    getAsArray(object, path) {
+      return getAsArray(object, path);
+    },
+  },
+};
+</script>

--- a/packages/common/leaders/browser/data-card-content.vue
+++ b/packages/common/leaders/browser/data-card-content.vue
@@ -36,12 +36,15 @@ export default {
     },
     promotions: {
       type: Array,
+      default: () => ([]),
     },
     youtube: {
       type: Object,
+      default: () => ({}),
     },
     youtubeVideos: {
       type: Object,
+      default: () => ({}),
     },
   },
   data() {
@@ -57,8 +60,8 @@ export default {
           linkText: get(video, 'snippet.title'),
           linkUrl,
           imageSrc: get(video, 'snippet.thumbnails.default.url'),
-        }
-      })
+        };
+      });
     },
     videosPath() {
       const username = get(this.youtube, 'username');

--- a/packages/common/leaders/browser/data-card-content.vue
+++ b/packages/common/leaders/browser/data-card-content.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script>
-import { get, getAsArray } from '@base-cms/object-path';
+import { get } from '@base-cms/object-path';
 
 import PromotionList from './promotion-list.vue';
 import VideoList from './video-list.vue';
@@ -38,11 +38,11 @@ export default {
       type: Array,
       default: () => ([]),
     },
-    youtube: {
-      type: Object,
-      default: () => ({}),
+    videos: {
+      type: Array,
+      default: () => ([]),
     },
-    youtubeVideos: {
+    youtube: {
       type: Object,
       default: () => ({}),
     },
@@ -51,18 +51,6 @@ export default {
     return {};
   },
   computed: {
-    videos() {
-      const videos = getAsArray(this.youtubeVideos, 'items');
-      return videos.map((video) => {
-        const id = get(video, 'snippet.resourceId.videoId');
-        const linkUrl = `https://youtu.be/${id}`;
-        return {
-          linkText: get(video, 'snippet.title'),
-          linkUrl,
-          imageSrc: get(video, 'snippet.thumbnails.default.url'),
-        };
-      });
-    },
     videosPath() {
       const username = get(this.youtube, 'username');
       if (username) return `https://youtube.com/user/${username}`;
@@ -74,9 +62,6 @@ export default {
   methods: {
     get(object, path) {
       return get(object, path);
-    },
-    getAsArray(object, path) {
-      return getAsArray(object, path);
     },
   },
 };

--- a/packages/common/leaders/browser/data-card-profile.vue
+++ b/packages/common/leaders/browser/data-card-profile.vue
@@ -2,11 +2,25 @@
   <div :class="classNames">
     <div class="row">
       <div class="ldc-left__logo col-6">
-        <img v-if="logoSrc" :src="logoSrc" :title="name" :alt="logoAlt" />
-        <h6 v-else>{{ name }}</h6>
+        <img
+          v-if="logoSrc"
+          :src="logoSrc"
+          :title="name"
+          :alt="logoAlt"
+        >
+        <h6 v-else>
+          {{ name }}
+        </h6>
       </div>
       <div class="ldc-left__buttons col-6">
-        <a v-if="website" :href="website" class="btn btn-block btn-sm btn-primary text-center" target="_blank">Visit Site</a>
+        <a
+          v-if="website"
+          :href="website"
+          class="btn btn-block btn-sm btn-primary text-center"
+          target="_blank"
+        >
+          Visit Site
+        </a>
         <a :href="path" class="btn btn-block btn-sm btn-secondary text-center">View Profile</a>
       </div>
     </div>
@@ -16,13 +30,15 @@
         <p v-if="productSummary">
           <strong>{{ productSummary }}</strong>
         </p>
-        <p v-if="teaser">{{ teaser }}</p>
+        <p v-if="teaser">
+          {{ teaser }}
+        </p>
       </div>
     </div>
     <hr v-if="contactName">
     <div v-if="contactName" class="row">
       <div v-if="contactSrc" class="col-3 my-auto">
-        <img :src="contactSrc" :title="contactName" :alt="contactAlt" />
+        <img :src="contactSrc" :title="contactName" :alt="contactAlt">
       </div>
       <div class="ldc-left__contact col">
         <p>
@@ -47,6 +63,7 @@ export default {
     },
     logoSrc: {
       type: String,
+      default: null,
     },
     path: {
       type: String,
@@ -54,21 +71,27 @@ export default {
     },
     productSummary: {
       type: String,
+      default: null,
     },
     contactName: {
       type: String,
+      default: null,
     },
     contactSrc: {
       type: String,
+      default: null,
     },
     contactTitle: {
       type: String,
+      default: null,
     },
     teaser: {
       type: String,
+      default: null,
     },
     website: {
       type: String,
+      default: null,
     },
   },
   computed: {

--- a/packages/common/leaders/browser/data-card-profile.vue
+++ b/packages/common/leaders/browser/data-card-profile.vue
@@ -1,0 +1,91 @@
+<template>
+  <div :class="classNames">
+    <div class="row">
+      <div class="ldc-left__logo col-6">
+        <img v-if="logoSrc" :src="logoSrc" :title="name" :alt="logoAlt" />
+        <h6 v-else>{{ name }}</h6>
+      </div>
+      <div class="ldc-left__buttons col-6">
+        <a v-if="website" :href="website" class="btn btn-block btn-sm btn-primary text-center" target="_blank">Visit Site</a>
+        <a :href="path" class="btn btn-block btn-sm btn-secondary text-center">View Profile</a>
+      </div>
+    </div>
+    <hr v-if="showTeaser">
+    <div v-if="showTeaser" class="row">
+      <div class="col">
+        <p v-if="productSummary">
+          <strong>{{ productSummary }}</strong>
+        </p>
+        <p v-if="teaser">{{ teaser }}</p>
+      </div>
+    </div>
+    <hr v-if="contactName">
+    <div v-if="contactName" class="row">
+      <div v-if="contactSrc" class="col-3 my-auto">
+        <img :src="contactSrc" :title="contactName" :alt="contactAlt" />
+      </div>
+      <div class="ldc-left__contact col">
+        <p>
+          {{ contactName }}
+          <span v-if="contactTitle">{{ contactTitle }}</span>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    compact: {
+      type: Boolean,
+      default: false,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    logoSrc: {
+      type: String,
+    },
+    path: {
+      type: String,
+      required: true,
+    },
+    productSummary: {
+      type: String,
+    },
+    contactName: {
+      type: String,
+    },
+    contactSrc: {
+      type: String,
+    },
+    contactTitle: {
+      type: String,
+    },
+    teaser: {
+      type: String,
+    },
+    website: {
+      type: String,
+    },
+  },
+  computed: {
+    showTeaser() {
+      return this.productSummary || this.teaser;
+    },
+    logoAlt() {
+      return `${this.name} logo`;
+    },
+    contactAlt() {
+      return `${this.contactName} headshot`;
+    },
+    classNames() {
+      const classes = ['ldc-left'];
+      if (!this.compact) classes.push('col-lg-4');
+      return classes;
+    },
+  },
+};
+</script>

--- a/packages/common/leaders/browser/data-card.vue
+++ b/packages/common/leaders/browser/data-card.vue
@@ -1,64 +1,49 @@
 <template>
   <div :class="classNames">
     <div class="row">
-      <div class="ldc-left col-lg-4">
-        <div class="row">
-          <div class="ldc-left__logo col-6">
-            <img v-if="logoSrc" :src="logoSrc" :title="name" :alt="logoAlt" />
-            <h6 v-else>{{ name }}</h6>
-          </div>
-          <div class="ldc-left__buttons col-6">
-            <a v-if="website" :href="website" class="btn btn-block btn-sm btn-primary text-center" target="_blank">Visit Site</a>
-            <a :href="path" class="btn btn-block btn-sm btn-secondary text-center">View Profile</a>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col">
-            <p v-if="productSummary">
-              <strong>{{ productSummary }}</strong>
-            </p>
-            <p v-if="teaser">{{ teaser }}</p>
-          </div>
-        </div>
-        <div v-if="contactName" class="row">
-          <div v-if="contactSrc" class="col-3 my-auto">
-            <img :src="contactSrc" :title="contactName" :alt="contactAlt" />
-          </div>
-          <div class="ldc-left__contact col">
-            <p>
-              {{ contactName }}
-              <span v-if="contactTitle">{{ contactTitle }}</span>
-            </p>
-          </div>
-        </div>
-      </div>
-      <div class="ldc-right col-lg-8">
-        <div v-if="promotions.length" class="row">
-          <div class="col">
-            <PromotionList :promotions="promotions" :path="path" :name="name" />
-          </div>
-        </div>
-        <div class="row">
-          <div class="col">
-            Featured Videos
-          </div>
-        </div>
-      </div>
+      <Profile
+        :compact="compact"
+        :logo-src="logoSrc"
+        :contact-src="contactSrc"
+        :website="website"
+        :name="name"
+        :product-summary="productSummary"
+        :contact-name="contactName"
+        :contact-title="contactTitle"
+        :path="path"
+        :teaser="teaser"
+      />
+      <Content
+        v-if="!compact"
+        :name="name"
+        :path="path"
+        :youtube="youtube"
+        :youtube-videos="youtubeVideos"
+        :promotions="promotions"
+      />
     </div>
   </div>
 </template>
 
 <script>
-import PromotionList from './promotion-list.vue';
+import { get, getAsArray } from '@base-cms/object-path';
+
+import Profile from './data-card-profile.vue';
+import Content from './data-card-content.vue';
 
 export default {
   components: {
-    PromotionList,
+    Profile,
+    Content,
   },
   props: {
     expanded: {
       type: Boolean,
       default: false,
+    },
+    grow: {
+      type: String,
+      default: 'right',
     },
     name: {
       type: String,
@@ -92,22 +77,34 @@ export default {
     promotions: {
       type: Array,
     },
+    youtube: {
+      type: Object,
+    },
+    youtubeVideos: {
+      type: Object,
+    },
   },
   data() {
     return {};
   },
   computed: {
-    logoAlt() {
-      return `${this.name} logo`;
-    },
-    contactAlt() {
-      return `${this.contactName} headshot`;
+    compact() {
+      return !getAsArray(this.youtubeVideos, 'items').length && !this.promotions.length;
     },
     classNames() {
-      const classes = ['ldc-modal'];
+      const classes = ['ldc-modal', `ldc-modal--grow-${this.grow}`];
       if (this.expanded) classes.push('ldc-modal--expanded');
+      if (this.compact) classes.push('ldc-modal--compact');
       return classes;
-    }
+    },
+  },
+  methods: {
+    get(object, path) {
+      return get(object, path);
+    },
+    getAsArray(object, path) {
+      return getAsArray(object, path);
+    },
   },
 };
 </script>

--- a/packages/common/leaders/browser/data-card.vue
+++ b/packages/common/leaders/browser/data-card.vue
@@ -18,7 +18,7 @@
         :name="name"
         :path="path"
         :youtube="youtube"
-        :youtube-videos="youtubeVideos"
+        :videos="videos"
         :promotions="promotions"
       />
     </div>
@@ -26,8 +26,6 @@
 </template>
 
 <script>
-import { get, getAsArray } from '@base-cms/object-path';
-
 import Profile from './data-card-profile.vue';
 import Content from './data-card-content.vue';
 
@@ -85,11 +83,11 @@ export default {
       type: Array,
       default: () => ([]),
     },
-    youtube: {
-      type: Object,
-      default: () => ({}),
+    videos: {
+      type: Array,
+      default: () => ([]),
     },
-    youtubeVideos: {
+    youtube: {
       type: Object,
       default: () => ({}),
     },
@@ -99,21 +97,13 @@ export default {
   },
   computed: {
     compact() {
-      return !getAsArray(this.youtubeVideos, 'items').length && !this.promotions.length;
+      return !this.videos.length && !this.promotions.length;
     },
     classNames() {
       const classes = ['ldc-modal', `ldc-modal--grow-${this.grow}`];
       if (this.expanded) classes.push('ldc-modal--expanded');
       if (this.compact) classes.push('ldc-modal--compact');
       return classes;
-    },
-  },
-  methods: {
-    get(object, path) {
-      return get(object, path);
-    },
-    getAsArray(object, path) {
-      return getAsArray(object, path);
     },
   },
 };

--- a/packages/common/leaders/browser/data-card.vue
+++ b/packages/common/leaders/browser/data-card.vue
@@ -3,11 +3,9 @@
     <div class="row">
       <div class="ldc-left col-lg-4">
         <div class="row">
-          <div class="col-6">
-            <div class="ldc-left__logo">
-              <img v-if="logoSrc" :src="logoSrc" :title="name" :alt="logoAlt" />
-              <span v-else>{{ name }}</span>
-            </div>
+          <div class="ldc-left__logo col-6">
+            <img v-if="logoSrc" :src="logoSrc" :title="name" :alt="logoAlt" />
+            <h6 v-else>{{ name }}</h6>
           </div>
           <div class="ldc-left__buttons col-6">
             <a v-if="website" :href="website" class="btn btn-block btn-sm btn-primary text-center" target="_blank">Visit Site</a>
@@ -23,7 +21,7 @@
           </div>
         </div>
         <div v-if="contactName" class="row">
-          <div v-if="contactSrc" class="col-3">
+          <div v-if="contactSrc" class="col-3 my-auto">
             <img :src="contactSrc" :title="contactName" :alt="contactAlt" />
           </div>
           <div class="ldc-left__contact col">

--- a/packages/common/leaders/browser/data-card.vue
+++ b/packages/common/leaders/browser/data-card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ldc-modal">
+  <div :class="classNames">
     <div class="row">
       <div class="ldc-left col-lg-4">
         <div class="row">
@@ -54,6 +54,10 @@
 
 export default {
   props: {
+    expanded: {
+      type: Boolean,
+      default: false,
+    },
     name: {
       type: String,
       required: true,
@@ -93,6 +97,11 @@ export default {
     },
     contactAlt() {
       return `${this.contactName} headshot`;
+    },
+    classNames() {
+      const classes = ['ldc-modal'];
+      if (this.expanded) classes.push('ldc-modal--expanded');
+      return classes;
     }
   },
 };

--- a/packages/common/leaders/browser/data-card.vue
+++ b/packages/common/leaders/browser/data-card.vue
@@ -55,33 +55,43 @@ export default {
     },
     logoSrc: {
       type: String,
+      default: null,
     },
     productSummary: {
       type: String,
+      default: null,
     },
     contactName: {
       type: String,
+      default: null,
     },
     contactSrc: {
       type: String,
+      default: null,
     },
     contactTitle: {
       type: String,
+      default: null,
     },
     teaser: {
       type: String,
+      default: null,
     },
     website: {
       type: String,
+      default: null,
     },
     promotions: {
       type: Array,
+      default: () => ([]),
     },
     youtube: {
       type: Object,
+      default: () => ({}),
     },
     youtubeVideos: {
       type: Object,
+      default: () => ({}),
     },
   },
   data() {

--- a/packages/common/leaders/browser/data-card.vue
+++ b/packages/common/leaders/browser/data-card.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="ldc-modal">
+    <div class="row">
+      <div class="ldc-left col-lg-4">
+        <div class="row">
+          <div class="col-6">
+            <div class="ldc-left__logo">
+              <img v-if="logoSrc" :src="logoSrc" :title="name" :alt="logoAlt" />
+              <span v-else>{{ name }}</span>
+            </div>
+          </div>
+          <div class="ldc-left__buttons col-6">
+            <a v-if="website" :href="website" class="btn btn-block btn-sm btn-primary text-center" target="_blank">Visit Site</a>
+            <a :href="path" class="btn btn-block btn-sm btn-secondary text-center">View Profile</a>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col">
+            <p v-if="productSummary">
+              <strong>{{ productSummary }}</strong>
+            </p>
+            <p v-if="teaser">{{ teaser }}</p>
+          </div>
+        </div>
+        <div v-if="contactName" class="row">
+          <div v-if="contactSrc" class="col-3">
+            <img :src="contactSrc" :title="contactName" :alt="contactAlt" />
+          </div>
+          <div class="ldc-left__contact col">
+            <p>
+              {{ contactName }}
+              <span v-if="contactTitle">{{ contactTitle }}</span>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="ldc-right col-lg-8">
+        <div class="row">
+          <div class="col">
+            Featured Products
+          </div>
+        </div>
+        <div class="row">
+          <div class="col">
+            Featured Videos
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+    path: {
+      type: String,
+      required: true,
+    },
+    logoSrc: {
+      type: String,
+    },
+    productSummary: {
+      type: String,
+    },
+    contactName: {
+      type: String,
+    },
+    contactSrc: {
+      type: String,
+    },
+    contactTitle: {
+      type: String,
+    },
+    teaser: {
+      type: String,
+    },
+    website: {
+      type: String,
+    },
+  },
+  data() {
+    return {};
+  },
+  computed: {
+    logoAlt() {
+      return `${this.name} logo`;
+    },
+    contactAlt() {
+      return `${this.contactName} headshot`;
+    }
+  },
+};
+</script>

--- a/packages/common/leaders/browser/data-card.vue
+++ b/packages/common/leaders/browser/data-card.vue
@@ -33,9 +33,9 @@
         </div>
       </div>
       <div class="ldc-right col-lg-8">
-        <div class="row">
+        <div v-if="promotions.length" class="row">
           <div class="col">
-            Featured Products
+            <PromotionList :promotions="promotions" :path="path" :name="name" />
           </div>
         </div>
         <div class="row">
@@ -49,8 +49,12 @@
 </template>
 
 <script>
+import PromotionList from './promotion-list.vue';
 
 export default {
+  components: {
+    PromotionList,
+  },
   props: {
     expanded: {
       type: Boolean,
@@ -84,6 +88,9 @@ export default {
     },
     website: {
       type: String,
+    },
+    promotions: {
+      type: Array,
     },
   },
   data() {

--- a/packages/common/leaders/browser/item-static.vue
+++ b/packages/common/leaders/browser/item-static.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="text-left">
-    <p class="mb-1 ml-3 font-weight-bold">{{ name }}:</p>
+    <p class="mb-1 ml-3 font-weight-bold">
+      {{ name }}:
+    </p>
     <ul class="leaders__item-list">
       <li v-if="loading" class="leaders__item-list-item">
         Loading...
@@ -23,13 +25,10 @@
 </template>
 
 <script>
-import { getAsArray } from '@base-cms/object-path';
-import IconYoutube from '@base-cms/marko-web-icons/browser/youtube.vue';
 import Company from './company.vue';
 
 export default {
   components: {
-    IconYoutube,
     Company,
   },
   props: {

--- a/packages/common/leaders/browser/item-static.vue
+++ b/packages/common/leaders/browser/item-static.vue
@@ -16,6 +16,7 @@
         v-else
         :key="content.id"
         :company="content"
+        grow="right"
       />
     </ul>
   </div>
@@ -69,10 +70,7 @@ export default {
         throw new Error(res.statusText);
       }
       const items = await res.json();
-      this.items = items.map((item) => {
-        const showIcon = getAsArray(item, 'socialLinks').some(({ provider }) => provider === 'youtube');
-        return { ...item, showIcon };
-      });
+      this.items = items;
     } catch (e) {
       this.error = e;
     } finally {

--- a/packages/common/leaders/browser/item-static.vue
+++ b/packages/common/leaders/browser/item-static.vue
@@ -11,17 +11,12 @@
       <li v-else-if="!items.length" class="leaders__item-list-item">
         No results found.
       </li>
-      <li
+      <Company
         v-for="content in items"
         v-else
         :key="content.id"
-        class="leaders__item-list-item"
-      >
-        <a :href="content.siteContext.path" :title="content.name">
-          {{ content.name }}
-          <IconYoutube v-if="content.showIcon" />
-        </a>
-      </li>
+        :company="content"
+      />
     </ul>
   </div>
 </template>
@@ -29,10 +24,12 @@
 <script>
 import { getAsArray } from '@base-cms/object-path';
 import IconYoutube from '@base-cms/marko-web-icons/browser/youtube.vue';
+import Company from './company.vue';
 
 export default {
   components: {
     IconYoutube,
+    Company,
   },
   props: {
     id: {

--- a/packages/common/leaders/browser/item.vue
+++ b/packages/common/leaders/browser/item.vue
@@ -20,6 +20,7 @@
         :key="content.id"
         class="leaders__item-list-item"
         :company="content"
+        grow="left"
       />
     </ul>
   </li>
@@ -85,10 +86,7 @@ export default {
           throw new Error(res.statusText);
         }
         const items = await res.json();
-        this.items = items.map((item) => {
-          const showIcon = getAsArray(item, 'socialLinks').some(({ provider }) => provider === 'youtube');
-          return { ...item, showIcon };
-        });
+        this.items = items;
       } catch (e) {
         this.error = e;
       } finally {

--- a/packages/common/leaders/browser/item.vue
+++ b/packages/common/leaders/browser/item.vue
@@ -14,17 +14,13 @@
       <li v-else-if="!items.length" class="leaders__item-list-item">
         No results found.
       </li>
-      <li
+      <Company
         v-for="content in items"
         v-else
         :key="content.id"
         class="leaders__item-list-item"
-      >
-        <a :href="content.siteContext.path" :title="content.name">
-          {{ content.name }}
-          <IconYoutube v-if="content.showIcon" />
-        </a>
-      </li>
+        :company="content"
+      />
     </ul>
   </li>
 </template>
@@ -33,13 +29,13 @@
 import { getAsArray } from '@base-cms/object-path';
 import IconDash from '@base-cms/marko-web-icons/browser/dash.vue';
 import IconPlus from '@base-cms/marko-web-icons/browser/plus.vue';
-import IconYoutube from '@base-cms/marko-web-icons/browser/youtube.vue';
+import Company from './company.vue';
 
 export default {
   components: {
     IconDash,
     IconPlus,
-    IconYoutube,
+    Company,
   },
   props: {
     id: {

--- a/packages/common/leaders/browser/item.vue
+++ b/packages/common/leaders/browser/item.vue
@@ -27,7 +27,6 @@
 </template>
 
 <script>
-import { getAsArray } from '@base-cms/object-path';
 import IconDash from '@base-cms/marko-web-icons/browser/dash.vue';
 import IconPlus from '@base-cms/marko-web-icons/browser/plus.vue';
 import Company from './company.vue';

--- a/packages/common/leaders/browser/promotion-list-item.vue
+++ b/packages/common/leaders/browser/promotion-list-item.vue
@@ -1,10 +1,15 @@
 <template>
-  <a v-if="url" target="_blank" :href="url" :title="text">
-    <img v-if="src" :src="src" :alt="text" />
+  <a
+    v-if="url"
+    target="_blank"
+    :href="url"
+    :title="text"
+  >
+    <img v-if="src" :src="src" :alt="text">
     <span>{{ text }}</span>
   </a>
   <div v-else>
-    <img v-if="src" :src="src" :alt="text" />
+    <img v-if="src" :src="src" :alt="text">
     <span>{{ text }}</span>
   </div>
 </template>
@@ -19,9 +24,11 @@ export default {
     },
     url: {
       type: String,
+      default: null,
     },
     src: {
       type: String,
+      default: null,
     },
   },
   data() {

--- a/packages/common/leaders/browser/promotion-list-item.vue
+++ b/packages/common/leaders/browser/promotion-list-item.vue
@@ -1,0 +1,31 @@
+<template>
+  <a v-if="url" target="_blank" :href="url" :title="text">
+    <img v-if="src" :src="src" :alt="text" />
+    <span>{{ text }}</span>
+  </a>
+  <div v-else>
+    <img v-if="src" :src="src" :alt="text" />
+    <span>{{ text }}</span>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    text: {
+      type: String,
+      required: true,
+    },
+    url: {
+      type: String,
+    },
+    src: {
+      type: String,
+    },
+  },
+  data() {
+    return {};
+  },
+};
+</script>

--- a/packages/common/leaders/browser/promotion-list.vue
+++ b/packages/common/leaders/browser/promotion-list.vue
@@ -2,7 +2,13 @@
   <div class="ldc-content">
     <div class="ldc-content__header">
       Featured {{ name }} Products
-      <a :href="path" title="View more products" class="ldc-content__more">View more products &gt;</a>
+      <a
+        :href="path"
+        title="View more products"
+        class="ldc-content__more"
+      >
+        View more products &gt;
+      </a>
     </div>
     <div class="ldc-content__list">
       <PromotionListItem
@@ -36,6 +42,7 @@ export default {
     },
     promotions: {
       type: Array,
+      default: () => ([]),
     },
   },
   data() {
@@ -44,7 +51,7 @@ export default {
   methods: {
     get(object, path) {
       return get(object, path);
-    }
+    },
   },
 };
 </script>

--- a/packages/common/leaders/browser/promotion-list.vue
+++ b/packages/common/leaders/browser/promotion-list.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="ldc-content">
+    <div class="ldc-content__header">
+      Featured {{ name }} Products
+      <a :href="path" title="View more products" class="ldc-content__more">View more products &gt;</a>
+    </div>
+    <div class="ldc-content__list">
+      <PromotionListItem
+        v-for="promotion in promotions"
+        :key="promotion.id"
+        class="ldc-content__list-item"
+        :url="promotion.linkUrl"
+        :text="promotion.linkText"
+        :src="get(promotion, 'primaryImage.src')"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { get } from '@base-cms/object-path';
+import PromotionListItem from './promotion-list-item.vue';
+
+export default {
+  components: {
+    PromotionListItem,
+  },
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+    path: {
+      type: String,
+      required: true,
+    },
+    promotions: {
+      type: Array,
+    },
+  },
+  data() {
+    return {};
+  },
+  methods: {
+    get(object, path) {
+      return get(object, path);
+    }
+  },
+};
+</script>

--- a/packages/common/leaders/browser/video-list-item.vue
+++ b/packages/common/leaders/browser/video-list-item.vue
@@ -1,10 +1,15 @@
 <template>
-  <a v-if="url" target="_blank" :href="url" :title="text">
-    <img v-if="src" :src="src" :alt="text" />
+  <a
+    v-if="url"
+    target="_blank"
+    :href="url"
+    :title="text"
+  >
+    <img v-if="src" :src="src" :alt="text">
     <span>{{ text }}</span>
   </a>
   <div v-else>
-    <img v-if="src" :src="src" :alt="text" />
+    <img v-if="src" :src="src" :alt="text">
     <span>{{ text }}</span>
   </div>
 </template>
@@ -19,9 +24,11 @@ export default {
     },
     url: {
       type: String,
+      default: null,
     },
     src: {
       type: String,
+      default: null,
     },
   },
   data() {

--- a/packages/common/leaders/browser/video-list-item.vue
+++ b/packages/common/leaders/browser/video-list-item.vue
@@ -1,0 +1,31 @@
+<template>
+  <a v-if="url" target="_blank" :href="url" :title="text">
+    <img v-if="src" :src="src" :alt="text" />
+    <span>{{ text }}</span>
+  </a>
+  <div v-else>
+    <img v-if="src" :src="src" :alt="text" />
+    <span>{{ text }}</span>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    text: {
+      type: String,
+      required: true,
+    },
+    url: {
+      type: String,
+    },
+    src: {
+      type: String,
+    },
+  },
+  data() {
+    return {};
+  },
+};
+</script>

--- a/packages/common/leaders/browser/video-list.vue
+++ b/packages/common/leaders/browser/video-list.vue
@@ -16,9 +16,9 @@
         v-for="video in videos"
         :key="video.id"
         class="ldc-content__list-item"
-        :url="video.linkUrl"
-        :text="video.linkText"
-        :src="video.imageSrc"
+        :url="video.url"
+        :text="video.title"
+        :src="video.thumbnail"
       />
     </div>
   </div>

--- a/packages/common/leaders/browser/video-list.vue
+++ b/packages/common/leaders/browser/video-list.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="ldc-content">
+    <div class="ldc-content__header">
+      Featured {{ name }} Videos
+      <a :href="path" title="View more videos" target="_blank" class="ldc-content__more">View more videos &gt;</a>
+    </div>
+    <div class="ldc-content__list">
+      <VideoListItem
+        v-for="video in videos"
+        :key="video.id"
+        class="ldc-content__list-item"
+        :url="video.linkUrl"
+        :text="video.linkText"
+        :src="video.imageSrc"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { get } from '@base-cms/object-path';
+import VideoListItem from './promotion-list-item.vue';
+
+export default {
+  components: {
+    VideoListItem,
+  },
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+    path: {
+      type: String,
+      required: true,
+    },
+    videos: {
+      type: Array,
+    },
+  },
+  data() {
+    return {};
+  },
+  methods: {
+    get(object, path) {
+      return get(object, path);
+    }
+  },
+};
+</script>

--- a/packages/common/leaders/browser/video-list.vue
+++ b/packages/common/leaders/browser/video-list.vue
@@ -2,7 +2,14 @@
   <div class="ldc-content">
     <div class="ldc-content__header">
       Featured {{ name }} Videos
-      <a :href="path" title="View more videos" target="_blank" class="ldc-content__more">View more videos &gt;</a>
+      <a
+        :href="path"
+        title="View more videos"
+        target="_blank"
+        class="ldc-content__more"
+      >
+        View more videos &gt;
+      </a>
     </div>
     <div class="ldc-content__list">
       <VideoListItem
@@ -36,6 +43,7 @@ export default {
     },
     videos: {
       type: Array,
+      default: () => ([]),
     },
   },
   data() {
@@ -44,7 +52,7 @@ export default {
   methods: {
     get(object, path) {
       return get(object, path);
-    }
+    },
   },
 };
 </script>

--- a/packages/common/leaders/graphql/queries/section-content.js
+++ b/packages/common/leaders/graphql/queries/section-content.js
@@ -15,8 +15,9 @@ query LeadersScheduledContent($input:WebsiteScheduledContentQueryInput!) {
             provider
           }
         }
-        primaryImage {
-          src
+        primaryImage{
+          id
+          src(input: { options: { auto: "format", fillColor: "fff", fit: "fill", h: 100, w: 100, pad: 5, mask: "ellipse" } })
         }
         ... on ContentCompany {
           productSummary
@@ -27,7 +28,8 @@ query LeadersScheduledContent($input:WebsiteScheduledContentQueryInput!) {
                 name
                 title
                 primaryImage {
-                  src
+                  id
+                  src(input: { options: { auto: "format", h: 50, w: 50, mask: "ellipse", fit: "facearea", facepad: 3 } })
                 }
               }
             }

--- a/packages/common/leaders/graphql/queries/section-content.js
+++ b/packages/common/leaders/graphql/queries/section-content.js
@@ -34,9 +34,9 @@ query LeadersScheduledContent($input:WebsiteScheduledContentQueryInput!) {
               }
             }
           }
-          teaser(input:{maxLength:0})
+          teaser(input: { maxLength: 0 })
           website
-          promotions: relatedContent(input:{queryTypes:[company], includeContentTypes:[Promotion]}){
+          promotions: relatedContent(input:{ queryTypes: [company], includeContentTypes: [Promotion] }){
             edges {
               node {
                 id

--- a/packages/common/leaders/graphql/queries/section-content.js
+++ b/packages/common/leaders/graphql/queries/section-content.js
@@ -56,18 +56,13 @@ query LeadersScheduledContent($input:WebsiteScheduledContentQueryInput!) {
             username
             channelId
           }
-          youtubeVideos(input: { limit: 4 }) {
-            items {
-              snippet {
+          videos: youtubeVideos(input: { pagination: { limit: 4 } }) {
+            edges {
+              node {
+                id
+                url
                 title
-                thumbnails {
-                  default {
-                    url
-                  }
-                }
-                resourceId {
-                  videoId
-                }
+                thumbnail
               }
             }
           }

--- a/packages/common/leaders/graphql/queries/section-content.js
+++ b/packages/common/leaders/graphql/queries/section-content.js
@@ -34,7 +34,7 @@ query LeadersScheduledContent($input:WebsiteScheduledContentQueryInput!) {
               }
             }
           }
-          teaser
+          teaser(input:{maxLength:0})
           website
           promotions: relatedContent(input:{queryTypes:[company], includeContentTypes:[Promotion]}){
             edges {
@@ -43,11 +43,30 @@ query LeadersScheduledContent($input:WebsiteScheduledContentQueryInput!) {
                 name
                 primaryImage{
                   id
-                  src(input: { options: { auto: "format", fit: "crop", h: 60, w: 110 } })
+                  src(input: { options: { auto: "format", fit: "crop", h: 90, w: 120 } })
                 }
                 ... on ContentPromotion {
                   linkUrl
                   linkText
+                }
+              }
+            }
+          }
+          youtube {
+            username
+            channelId
+          }
+          youtubeVideos(input: { limit: 4 }) {
+            items {
+              snippet {
+                title
+                thumbnails {
+                  default {
+                    url
+                  }
+                }
+                resourceId {
+                  videoId
                 }
               }
             }

--- a/packages/common/leaders/graphql/queries/section-content.js
+++ b/packages/common/leaders/graphql/queries/section-content.js
@@ -36,6 +36,22 @@ query LeadersScheduledContent($input:WebsiteScheduledContentQueryInput!) {
           }
           teaser
           website
+          promotions: relatedContent(input:{queryTypes:[company], includeContentTypes:[Promotion]}){
+            edges {
+              node {
+                id
+                name
+                primaryImage{
+                  id
+                  src(input: { options: { auto: "format", fit: "crop", h: 60, w: 110 } })
+                }
+                ... on ContentPromotion {
+                  linkUrl
+                  linkText
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/packages/common/leaders/graphql/queries/section-content.js
+++ b/packages/common/leaders/graphql/queries/section-content.js
@@ -15,6 +15,26 @@ query LeadersScheduledContent($input:WebsiteScheduledContentQueryInput!) {
             provider
           }
         }
+        primaryImage {
+          src
+        }
+        ... on ContentCompany {
+          productSummary
+          publicContacts {
+            edges {
+              node {
+                id
+                name
+                title
+                primaryImage {
+                  src
+                }
+              }
+            }
+          }
+          teaser
+          website
+        }
       }
     }
   }

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -23,3 +23,77 @@
     }
   }
 }
+
+.ldc-modal {
+  @include theme-card();
+  position: absolute;
+  right: 4rem;
+  bottom: 0;
+  z-index: 10;
+  max-height: 600px;
+  margin: 1.5rem;
+  overflow: scroll;
+  font-size: 80%;
+  font-weight: 400;
+  background-color: #eff0f1;
+  & .row {
+    margin: 0;
+  }
+  @include media-breakpoint-up(lg) {
+    width: 800px;
+  }
+  @include media-breakpoint-down(md) {
+    width: 600px;
+  }
+  @include media-breakpoint-down(sm) {
+    width: 300px;
+  }
+}
+
+
+.ldc-left,
+.ldc-right {
+  @include make-col-ready();
+  padding: .5rem;
+}
+
+.ldc-left {
+  padding: .5rem;
+  &__logo,
+  &__buttons {
+    @include make-col-ready();
+    width: 50%;
+  }
+  &__logo {
+    width: 100px;
+    padding: 0;
+    margin: 0;
+    // clip-path: circle(40px at center);
+    & > img {
+      width: 100px;
+      height: 100px;
+    }
+  }
+  &__buttons {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  &__contact {
+    margin-top: auto;
+    margin-bottom: auto;
+    & > p > span::before {
+      margin-left: -.25rem;
+      content: ", ";
+    }
+  }
+  & .row:not(:last-child) {
+    padding-bottom: .5rem;
+    margin-bottom: .5rem;
+    border-bottom: 1px solid #ccc;
+  }
+}
+
+.ldc-right {
+  background-color: #fff;
+}

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -26,48 +26,33 @@
 
 .ldc-modal {
   @include theme-card();
-  box-shadow: 0 3px 9px rgba(0, 0, 0, .35);
-  border: none;
   position: absolute;
-  right: 100%;
+  right: 4rem;
+  bottom: 0;
   z-index: 10;
-  height: auto;
-  max-height: 100vh;
-  overflow-y: scroll;
+  max-height: 600px;
+  margin: 1.5rem;
+  overflow: scroll;
   font-size: 80%;
   font-weight: 400;
   background-color: #eff0f1;
-  width: 75vh;
-  padding-right: .5rem;
-  transform: translateY(50%);
+  box-shadow: 0 3px 9px rgba(0, 0, 0, .35);
+  & .row {
+    margin: 0;
+  }
+  @include media-breakpoint-up(lg) {
+    width: 800px;
+  }
+  @include media-breakpoint-down(md) {
+    width: 600px;
+  }
+  @include media-breakpoint-down(sm) {
+    width: 300px;
+  }
 
-  // position: absolute;
-  // right: 4rem;
-  // bottom: 0;
-  // z-index: 10;
-  // display: none;
-  // max-height: 600px;
-  // margin: 1.5rem;
-  // overflow: scroll;
-  // font-size: 80%;
-  // font-weight: 400;
-  // background-color: #eff0f1;
-  // & .row {
-  //   margin: 0;
-  // }
-  // @include media-breakpoint-up(lg) {
-  //   width: 800px;
-  // }
-  // @include media-breakpoint-down(md) {
-  //   width: 600px;
-  // }
-  // @include media-breakpoint-down(sm) {
-  //   width: 300px;
-  // }
-
-  // &--expanded {
-  //   display: block;
-  // }
+  &--expanded {
+    display: block;
+  }
 }
 
 
@@ -85,13 +70,26 @@
     width: 50%;
   }
   &__logo {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
     width: 100px;
+    height: 100px;
     padding: 0;
     margin: 0;
-    // clip-path: circle(40px at center);
+    text-align: center;
+    & > h6 {
+      margin: 0;
+    }
     & > img {
+      display: block;
       width: 100px;
       height: 100px;
+      margin: auto;
+      margin-bottom: auto;
+      border: 3px solid #fff;
+      border-radius: 100px;
+      box-shadow: inset 0 0 5px rgba(0, 0, 0, .5);
     }
   }
   &__buttons {

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -10,6 +10,9 @@
       text-decoration: none;
     }
   }
+  &__item-list-item {
+    position: relative;
+  }
 }
 
 .node-list {

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -114,4 +114,28 @@
 
 .ldc-right {
   background-color: #fff;
+  & .row:not(:last-child) {
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid #ccc;
+  }
+}
+
+.ldc-content {
+  &__list {
+    display: flex;
+    justify-content: space-between;
+  }
+  &__more {
+    float: right;
+  }
+  &__list-item {
+    display: flex;
+    flex-direction: column;
+    max-width: 110px;
+    & img {
+      margin-right: auto;
+      margin-left: auto;
+    }
+  }
 }

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -16,10 +16,25 @@
 }
 
 .node-list {
+  $self: &;
   &__header,
   &__body {
     &--centered {
       text-align: center;
+    }
+  }
+  &--leaders {
+    #{ $self }__header {
+      background-color: $leaders-header-background-color;
+    }
+    .leaders {
+      &__item,
+      &__item-list-item {
+        button,
+        a:not(.btn) {
+          color: $leaders-link-color;
+        }
+      }
     }
   }
 }

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -26,28 +26,48 @@
 
 .ldc-modal {
   @include theme-card();
+  box-shadow: 0 3px 9px rgba(0, 0, 0, .35);
+  border: none;
   position: absolute;
-  right: 4rem;
-  bottom: 0;
+  right: 100%;
   z-index: 10;
-  max-height: 600px;
-  margin: 1.5rem;
-  overflow: scroll;
+  height: auto;
+  max-height: 100vh;
+  overflow-y: scroll;
   font-size: 80%;
   font-weight: 400;
   background-color: #eff0f1;
-  & .row {
-    margin: 0;
-  }
-  @include media-breakpoint-up(lg) {
-    width: 800px;
-  }
-  @include media-breakpoint-down(md) {
-    width: 600px;
-  }
-  @include media-breakpoint-down(sm) {
-    width: 300px;
-  }
+  width: 75vh;
+  padding-right: .5rem;
+  transform: translateY(50%);
+
+  // position: absolute;
+  // right: 4rem;
+  // bottom: 0;
+  // z-index: 10;
+  // display: none;
+  // max-height: 600px;
+  // margin: 1.5rem;
+  // overflow: scroll;
+  // font-size: 80%;
+  // font-weight: 400;
+  // background-color: #eff0f1;
+  // & .row {
+  //   margin: 0;
+  // }
+  // @include media-breakpoint-up(lg) {
+  //   width: 800px;
+  // }
+  // @include media-breakpoint-down(md) {
+  //   width: 600px;
+  // }
+  // @include media-breakpoint-down(sm) {
+  //   width: 300px;
+  // }
+
+  // &--expanded {
+  //   display: block;
+  // }
 }
 
 

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -27,7 +27,6 @@
 .ldc-modal {
   @include theme-card();
   position: absolute;
-  right: 4rem;
   bottom: 0;
   z-index: 10;
   max-height: 600px;
@@ -50,8 +49,21 @@
     width: 300px;
   }
 
+  & hr {
+    width: 100%;
+  }
+
+  &--grow-left {
+    left: 0;
+  }
+  &--grow-right {
+    right: 0;
+  }
   &--expanded {
     display: block;
+  }
+  &--compact {
+    width: 300px;
   }
 }
 
@@ -59,6 +71,9 @@
 .ldc-left,
 .ldc-right {
   @include make-col-ready();
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   padding: .5rem;
 }
 
@@ -105,23 +120,16 @@
       content: ", ";
     }
   }
-  & .row:not(:last-child) {
-    padding-bottom: .5rem;
-    margin-bottom: .5rem;
-    border-bottom: 1px solid #ccc;
-  }
 }
 
 .ldc-right {
   background-color: #fff;
-  & .row:not(:last-child) {
-    padding-bottom: 1rem;
-    margin-bottom: 1rem;
-    border-bottom: 1px solid #ccc;
-  }
 }
 
 .ldc-content {
+  &__header {
+    padding-bottom: .5rem;
+  }
   &__list {
     display: flex;
     justify-content: space-between;

--- a/sites/automationworld/server/styles/index.scss
+++ b/sites/automationworld/server/styles/index.scss
@@ -34,25 +34,10 @@ $theme-site-header-breakpoints: (
   small-text-secondary: 740px
 );
 
-@import "../../node_modules/@base-cms-websites/package-common/scss/common";
+$leaders-header-background-color: $light-bg-color;
+$leaders-link-color: #780116;
 
-.node-list {
-  $self: &;
-  &--leaders {
-    #{ $self }__header {
-      background-color: $light-bg-color;
-    }
-    .leaders {
-      &__item,
-      &__item-list-item {
-        button,
-        a {
-          color: #780116;
-        }
-      }
-    }
-  }
-}
+@import "../../node_modules/@base-cms-websites/package-common/scss/common";
 
 .load-more-trigger > button:hover {
   background-color: $light-bg-color;

--- a/sites/healthcarepackaging/server/styles/index.scss
+++ b/sites/healthcarepackaging/server/styles/index.scss
@@ -36,25 +36,10 @@ $theme-site-header-breakpoints: (
   small-text-secondary: 740px
 );
 
-@import "../../node_modules/@base-cms-websites/package-common/scss/common";
+$leaders-header-background-color: $light-bg-color;
+$leaders-link-color: $dark-bg-color;
 
-.node-list {
-  $self: &;
-  &--leaders {
-    #{ $self }__header {
-      background-color: $light-bg-color;
-    }
-    .leaders {
-      &__item,
-      &__item-list-item {
-        button,
-        a {
-          color: $dark-bg-color;
-        }
-      }
-    }
-  }
-}
+@import "../../node_modules/@base-cms-websites/package-common/scss/common";
 
 .load-more-trigger > button:hover {
   background-color: $light-bg-color;

--- a/sites/oemmagazine/server/styles/index.scss
+++ b/sites/oemmagazine/server/styles/index.scss
@@ -36,25 +36,10 @@ $theme-site-header-breakpoints: (
   small-text-secondary: 740px
 );
 
-@import "../../node_modules/@base-cms-websites/package-common/scss/common";
+$leaders-header-background-color: $light-bg-color;
+$leaders-link-color: $dark-bg-color;
 
-.node-list {
-  $self: &;
-  &--leaders {
-    #{ $self }__header {
-      background-color: $light-bg-color;
-    }
-    .leaders {
-      &__item,
-      &__item-list-item {
-        button,
-        a {
-          color: $dark-bg-color;
-        }
-      }
-    }
-  }
-}
+@import "../../node_modules/@base-cms-websites/package-common/scss/common";
 
 .load-more-trigger > button:hover {
   background-color: $light-bg-color;

--- a/sites/packworld/server/styles/index.scss
+++ b/sites/packworld/server/styles/index.scss
@@ -37,25 +37,10 @@ $theme-site-header-breakpoints: (
   small-text-secondary: 740px
 );
 
-@import "../../node_modules/@base-cms-websites/package-common/scss/common";
+$leaders-header-background-color: $dark-bg-color;
+$leaders-link-color: $dark-bg-color;
 
-.node-list {
-  $self: &;
-  &--leaders {
-    #{ $self }__header {
-      background-color: $dark-bg-color;
-    }
-    .leaders {
-      &__item,
-      &__item-list-item {
-        button,
-        a {
-          color: $dark-bg-color;
-        }
-      }
-    }
-  }
-}
+@import "../../node_modules/@base-cms-websites/package-common/scss/common";
 
 .load-more-trigger > button:hover {
   background-color: $light-bg-color;

--- a/sites/profoodworld/server/styles/index.scss
+++ b/sites/profoodworld/server/styles/index.scss
@@ -36,25 +36,10 @@ $theme-site-header-breakpoints: (
   small-text-secondary: 740px
 );
 
-@import "../../node_modules/@base-cms-websites/package-common/scss/common";
+$leaders-header-background-color: $light-bg-color;
+$leaders-link-color: $dark-bg-color;
 
-.node-list {
-  $self: &;
-  &--leaders {
-    #{ $self }__header {
-      background-color: $light-bg-color;
-    }
-    .leaders {
-      &__item,
-      &__item-list-item {
-        button,
-        a {
-          color: $dark-bg-color;
-        }
-      }
-    }
-  }
-}
+@import "../../node_modules/@base-cms-websites/package-common/scss/common";
 
 .load-more-trigger > button:hover {
   background-color: #8fb019;


### PR DESCRIPTION
Adds initial implementation of Leadership data cards _without_ advanced hover functionality. This version allows basic expansion to left or right of the container, and is offset so as to not let the data card chase the cursor.

This PR **requires** base-cms/base-cms#209 to be merged and deployed before it can be tagged for release, as it relies on new GraphQL and Google Data API functionality.

I'd like to get this reviewed and merged ahead of the new hover functionality so it's not held up by that (and doesn't force that implementation to cut corners to meet PMMI launch deadlines ;))

Reference design doc https://sketch.cloud/s/Dw4zk/a/kLVono

----

![Screen Shot 2019-10-25 at 5 50 31 PM](https://user-images.githubusercontent.com/1778222/67609094-c4a36e00-f750-11e9-83a0-d49ee7945317.png)
![Screen Shot 2019-10-25 at 5 52 40 PM](https://user-images.githubusercontent.com/1778222/67609095-c53c0480-f750-11e9-8471-9650afeb2236.png)
![Screen Shot 2019-10-25 at 5 52 32 PM](https://user-images.githubusercontent.com/1778222/67609096-c53c0480-f750-11e9-99b5-3a5530cc5747.png)
![Screen Shot 2019-10-25 at 5 51 06 PM](https://user-images.githubusercontent.com/1778222/67609097-c53c0480-f750-11e9-9a0d-fb493d611641.png)
![Screen Shot 2019-10-25 at 5 50 53 PM](https://user-images.githubusercontent.com/1778222/67609099-c53c0480-f750-11e9-8f90-84de4868b39d.png)
