### PR TITLE
Update leaders home page block

### DIFF
--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -17,7 +17,8 @@ $ const {
       </if>
       <if(columns > 1)>
         <div class="leaders__callout">
-          Browse these <div class="strong">leading suppliers</div>
+          <div>Browse these</div>
+          <div class="leaders__suppliers-callout">leading suppliers</div>
         </div>
       </if>
     </@header>

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -5,7 +5,6 @@ $ const {
   sectionAlias: alias,
   logoSrc: src,
   logoAlt: alt,
-  bodyText,
   columns,
 } = input;
 
@@ -17,9 +16,6 @@ $ const {
         <img src=src alt=alt class="leaders__logo" />
       </if>
     </@header>
-    <if(bodyText)>
-      <@body modifiers=["centered"] value=bodyText />
-    </if>
     <@nodes nodes=nodes>
       $ const colClass = columns === 2 ? "col-lg-6 mb-block list-unstyled" : "col list-unstyled";
       $ const mid = Math.floor(nodes.length / 2)

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -17,7 +17,7 @@ $ const {
       </if>
       <if(columns > 1)>
         <div class="leaders__callout">
-          Browse these <strong class="d-block">leading suppliers</strong>
+          Browse these <div class="strong">leading suppliers</div>
         </div>
       </if>
     </@header>

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -15,6 +15,11 @@ $ const {
       <if(src)>
         <img src=src alt=alt class="leaders__logo" />
       </if>
+      <if(columns > 1)>
+        <div class="leaders__callout">
+          Browse these <strong class="d-block">leading suppliers</strong>
+        </div>
+      </if>
     </@header>
     <@nodes nodes=nodes>
       $ const colClass = columns === 2 ? "col-lg-6 mb-block list-unstyled" : "col list-unstyled";

--- a/packages/common/leaders/components/marko.json
+++ b/packages/common/leaders/components/marko.json
@@ -5,7 +5,6 @@
       "@section-alias": "string",
       "@logo-src": "string",
       "@logo-alt": "string",
-      "@body-text": "string",
       "@columns": {
         "type": "number",
         "default-value": 2

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -6,10 +6,10 @@
     align-items: center;
     font-size: 1.25rem;
     text-align: left;
-    div {
-      font-size: 1.5rem;
-      font-weight: 600;
-    }
+  }
+  &__suppliers-callout {
+    font-size: 1.5rem;
+    font-weight: 600;
   }
   &__item {
     text-align: left;

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -6,9 +6,9 @@
     align-items: center;
     font-size: 1.25rem;
     text-align: left;
-    cursor: default;
-    strong {
+    div {
       font-size: 1.5rem;
+      font-weight: 600;
     }
   }
   &__item {

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -2,6 +2,15 @@
   &__logo {
     max-width: 100%;
   }
+  &__callout {
+    align-items: center;
+    font-size: 1.25rem;
+    text-align: left;
+    cursor: default;
+    strong {
+      font-size: 1.5rem;
+    }
+  }
   &__item {
     text-align: left;
     .btn-link:hover,
@@ -25,6 +34,9 @@
   }
   &--leaders {
     #{ $self }__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-around;
       background-color: $leaders-header-background-color;
     }
     .leaders {

--- a/sites/automationworld/server/templates/index.marko
+++ b/sites/automationworld/server/templates/index.marko
@@ -115,7 +115,6 @@ $ const { id, alias, name, pageNode } = data;
           section-alias="leaders"
           logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/aw.png"
           logo-alt="Leaders in Automation"
-          body-text="Browse these leading suppliers:"
         />
       </div>
       <div class="col-lg-4 mb-block page-rail">

--- a/sites/healthcarepackaging/server/templates/index.marko
+++ b/sites/healthcarepackaging/server/templates/index.marko
@@ -61,7 +61,6 @@ $ const { id, alias, name, pageNode } = data;
           section-alias="leaders"
           logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/hcp.png"
           logo-alt="Premiere Suppliers"
-          body-text="Browse these leading suppliers:"
         />
       </div>
       <div class="col-lg-4 mb-block page-rail">

--- a/sites/oemmagazine/server/templates/index.marko
+++ b/sites/oemmagazine/server/templates/index.marko
@@ -61,7 +61,6 @@ $ const { id, alias, name, pageNode } = data;
           section-alias="leaders"
           logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/oem.png"
           logo-alt="OEM Tech Trendsetters"
-          body-text="Browse these leading suppliers:"
         />
       </div>
       <div class="col-lg-4 mb-block page-rail">

--- a/sites/packworld/server/templates/index.marko
+++ b/sites/packworld/server/templates/index.marko
@@ -61,7 +61,6 @@ $ const { id, alias, name, pageNode } = data;
           section-alias="leaders"
           logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/pw.png"
           logo-alt="Leaders in Packaging"
-          body-text="Browse these leading suppliers:"
         />
       </div>
       <div class="col-lg-4 mb-block page-rail">

--- a/sites/profoodworld/server/templates/index.marko
+++ b/sites/profoodworld/server/templates/index.marko
@@ -61,7 +61,6 @@ $ const { id, alias, name, pageNode } = data;
           section-alias="leaders"
           logo-src="https://base.imgix.net/files/base/pmmi/all/leaders/pfw.png"
           logo-alt="Leaders in Processing"
-          body-text="Browse these leading suppliers:"
         />
       </div>
       <div class="col-lg-4 mb-block page-rail">


### PR DESCRIPTION
Add "browse these leading suppliers" text to the homepage block header
Ref design https://sketch.cloud/s/Dw4zk/a/5Yx01x

![Screen Shot 2019-10-28 at 9 41 21 PM](https://user-images.githubusercontent.com/1778222/67733249-d80e3d80-f9cb-11e9-9693-84b98ddee027.png)
![Screen Shot 2019-10-28 at 9 42 16 PM](https://user-images.githubusercontent.com/1778222/67733250-d80e3d80-f9cb-11e9-8a12-5f0c0ff16c3f.png)
