### PR TITLE
Address 2 column layout issues

### DIFF
--- a/packages/common/leaders/components/column-layout.marko
+++ b/packages/common/leaders/components/column-layout.marko
@@ -4,18 +4,27 @@ $ const columns = input.columns || 2;
 $ const nodes = getAsArray(input, 'nodes');
 
 $ const colClass = columns === 2 ? "col-md-6 mb-block list-unstyled" : "col list-unstyled";
-$ const mid = Math.floor(nodes.length / 2)
+$ const mid = Math.ceil(nodes.length / 2)
 $ const groups = columns == 2 ? [
   [...nodes.slice(0, mid)],
   [...nodes.slice(mid, nodes.length)],
 ] : [nodes];
 
 <if(nodes.length)>
-  <for|items| of=groups>
-    <ul class=colClass>
-      <for|{ id, name }| of=items>
-        <marko-web-browser-component name="CommonLeadersItem" props={ id, name } />
-      </for>
-    </ul>
-  </for>
+  <if(input.label)>
+  <div class="row">
+    <div class="col">
+      <label class="leaders__category leaders__category--bottom-border">${input.label}</label>
+    </div>
+  </div>
+  </if>
+  <div class="row">
+    <for|items| of=groups>
+      <ul class=colClass>
+        <for|{ id, name }| of=items>
+          <marko-web-browser-component name="CommonLeadersItem" props={ id, name } />
+        </for>
+      </ul>
+    </for>
+  </div>
 </if>

--- a/packages/common/leaders/components/column-layout.marko
+++ b/packages/common/leaders/components/column-layout.marko
@@ -1,0 +1,21 @@
+import { getAsArray } from "@base-cms/object-path";
+
+$ const columns = input.columns || 2;
+$ const nodes = getAsArray(input, 'nodes');
+
+$ const colClass = columns === 2 ? "col-md-6 mb-block list-unstyled" : "col list-unstyled";
+$ const mid = Math.floor(nodes.length / 2)
+$ const groups = columns == 2 ? [
+  [...nodes.slice(0, mid)],
+  [...nodes.slice(mid, nodes.length)],
+] : [nodes];
+
+<if(nodes.length)>
+  <for|items| of=groups>
+    <ul class=colClass>
+      <for|{ id, name }| of=items>
+        <marko-web-browser-component name="CommonLeadersItem" props={ id, name } />
+      </for>
+    </ul>
+  </for>
+</if>

--- a/packages/common/leaders/components/column-layout.marko
+++ b/packages/common/leaders/components/column-layout.marko
@@ -1,7 +1,7 @@
 import { getAsArray } from "@base-cms/object-path";
 
 $ const columns = input.columns || 2;
-$ const nodes = getAsArray(input, 'nodes');
+$ const nodes = getAsArray(input, "nodes");
 
 $ const colClass = columns === 2 ? "col-md-6 mb-block list-unstyled" : "col list-unstyled";
 $ const mid = Math.ceil(nodes.length / 2)

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -26,7 +26,7 @@ $ const {
       $ const hasChildren = nodes.some(node => getAsArray(node, "children.edges").length);
       <if(hasChildren)>
         <for|parent| of=nodes>
-          <label class="leaders__category">${parent.name}</label>
+          <label class="leaders__category leaders__category--bottom-border">${parent.name}</label>
           $ const children = getAsArray(parent, "children.edges").map(({ node: item }) => item);
           <leaders-column-layout columns=columns nodes=children />
         </for>

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -23,32 +23,17 @@ $ const {
       </if>
     </@header>
     <@nodes nodes=nodes>
-      $ const colClass = columns === 2 ? "col-lg-6 mb-block list-unstyled" : "col list-unstyled";
-      $ const mid = Math.floor(nodes.length / 2)
-      $ const groups = columns == 2 ? [
-        [...nodes.slice(0, mid)],
-        [...nodes.slice(mid, nodes.length)],
-      ] : [nodes];
-      <div class="row">
-        <for|group| of=groups>
-          <ul class=colClass>
-            <for|node| of=group>
-              $ const children = getAsArray(node, "children.edges").map(({ node: item }) => item);
-              <if(children.length)>
-                <li class="leaders__category">
-                  <label class="leaders__category-label">${node.name}</label>
-                </li>
-                <for|item| of=children>
-                  <marko-web-browser-component name="CommonLeadersItem" props={ id: item.id, name: item.name } />
-                </for>
-              </if>
-              <else>
-                <marko-web-browser-component name="CommonLeadersItem" props={ id: node.id, name: node.name } />
-              </else>
-            </for>
-          </ul>
+      $ const hasChildren = nodes.some(node => getAsArray(node, "children.edges").length);
+      <if(hasChildren)>
+        <for|parent| of=nodes>
+          <label class="leaders__category">${parent.name}</label>
+          $ const children = getAsArray(parent, "children.edges").map(({ node: item }) => item);
+          <leaders-column-layout columns=columns nodes=children />
         </for>
-      </div>
+      </if>
+      <else>
+        <leaders-column-layout columns=columns nodes=nodes />
+      </else>
     </@nodes>
   </marko-web-node-list>
 </marko-web-query>

--- a/packages/common/leaders/components/index.marko
+++ b/packages/common/leaders/components/index.marko
@@ -1,4 +1,4 @@
-import { getAsArray } from "@base-cms/object-path";
+import { get, getAsArray } from "@base-cms/object-path";
 import queryFragment from "../graphql/fragments/section";
 
 $ const {
@@ -10,7 +10,7 @@ $ const {
 
 <marko-web-query|{ node: leaders }| name="website-section" params={ alias, queryFragment }>
   $ const nodes = getAsArray(leaders, "children.edges").map(({ node }) => node);
-  <marko-web-node-list modifiers=["leaders"]>
+  <marko-web-node-list modifiers=["leaders"] collapsible=false>
     <@header modifiers=["centered"]>
       <if(src)>
         <img src=src alt=alt class="leaders__logo" />
@@ -22,18 +22,19 @@ $ const {
         </div>
       </if>
     </@header>
-    <@nodes nodes=nodes>
+    <@body>
       $ const hasChildren = nodes.some(node => getAsArray(node, "children.edges").length);
       <if(hasChildren)>
         <for|parent| of=nodes>
           <label class="leaders__category leaders__category--bottom-border">${parent.name}</label>
           $ const children = getAsArray(parent, "children.edges").map(({ node: item }) => item);
-          <leaders-column-layout columns=columns nodes=children />
+          $ const label = get(parent, "name");
+          <leaders-column-layout columns=columns nodes=children label=label />
         </for>
       </if>
       <else>
         <leaders-column-layout columns=columns nodes=nodes />
       </else>
-    </@nodes>
+    </@body>
   </marko-web-node-list>
 </marko-web-query>

--- a/packages/common/leaders/components/marko.json
+++ b/packages/common/leaders/components/marko.json
@@ -11,7 +11,9 @@
       }
     },
     "leaders-column-layout": {
+      "template": "./column-layout.marko",
       "@nodes": "array",
+      "@label": "string",
       "@columns": {
         "type": "number",
         "default-value": 2

--- a/packages/common/leaders/components/marko.json
+++ b/packages/common/leaders/components/marko.json
@@ -10,6 +10,13 @@
         "default-value": 2
       }
     },
+    "leaders-column-layout": {
+      "@nodes": "array",
+      "@columns": {
+        "type": "number",
+        "default-value": 2
+      }
+    },
     "leaders-block-contextual": {
       "template": "./contextual.marko",
       "@section-alias": "string",

--- a/packages/common/scss/company-page.scss
+++ b/packages/common/scss/company-page.scss
@@ -9,16 +9,4 @@
       box-shadow: inset 0 0 5px rgba(0, 0, 0, .5);
     }
   }
-  &__label {
-    display: block;
-    color: $gray-600;
-    text-transform: uppercase;
-    &--bottom-border {
-      padding-bottom: .25rem;
-      border-bottom: 1px solid rgba(0, 0, 0, .25);
-    }
-    &:not(:first-child) {
-      margin-top: 1.5rem;
-    }
-  }
 }

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -22,6 +22,19 @@
   &__item-list-item {
     position: relative;
   }
+  &__category {
+    display: block;
+    color: $gray-600;
+    text-align: left;
+    text-transform: uppercase;
+    &--bottom-border {
+      padding-bottom: .25rem;
+      border-bottom: 1px solid rgba(0, 0, 0, .25);
+    }
+    &:not(:first-child) {
+      margin-top: 1.5rem;
+    }
+  }
 }
 
 .node-list {

--- a/sites/automationworld/server/templates/content/company.marko
+++ b/sites/automationworld/server/templates/content/company.marko
@@ -56,9 +56,9 @@ $ const { id, type, pageNode } = data;
               Company Overview
             </@header>
             <@body>
-              <label class="ldp__label">About ${content.name}</label>
+              <label class="leaders__category">About ${content.name}</label>
               <marko-web-content-teaser tag="p" obj=content />
-              <label class="ldp__label">Product Summary</label>
+              <label class="leaders__category">Product Summary</label>
               <marko-web-obj-text tag="p" obj=content field="productSummary" type="content" html=true />
             </@body>
           </marko-web-node-list>
@@ -69,14 +69,14 @@ $ const { id, type, pageNode } = data;
               <else>Company Details</else>
             </@header>
             <@body>
-              <label class="ldp__label ldp__label--bottom-border">At-a-glance</label>
+              <label class="leaders__category leaders__category--bottom-border">At-a-glance</label>
               <common-company-details company=content />
 
-              <label class="ldp__label ldp__label--bottom-border">Contact</label>
+              <label class="leaders__category leaders__category--bottom-border">Contact</label>
               $ const { socialLinks, ...contentSansSocial } = content;
               <default-theme-content-contact-details obj=contentSansSocial />
 
-              <label class="ldp__label ldp__label--bottom-border">More info on ${content.name}</label>
+              <label class="leaders__category leaders__category--bottom-border">More info on ${content.name}</label>
               <marko-web-content-body obj=content />
             </@body>
           </marko-web-node-list>


### PR DESCRIPTION
- Adds proper label and HR per [design](https://sketch.cloud/s/Dw4zk/a/5Yx01x)
- Changes grouping logic to sort under each top-level category instead of grouping the top-levels
- Changes responsiveness to stay 2 columns on tablet size
- Fixes center alignment issue for labels in right rail

![Screen Shot 2019-10-28 at 11 04 06 PM](https://user-images.githubusercontent.com/1778222/67737126-1578c800-f9d8-11e9-8443-65d64e584801.png)
![screencapture-0-0-0-0-9711-2019-10-28-23_05_22](https://user-images.githubusercontent.com/1778222/67737137-1ad61280-f9d8-11e9-8102-a4bbd214f5c6.jpg)
![screencapture-0-0-0-0-9711-home-contact-13884577-anne-marie-mohan-2019-10-28-23_04_14](https://user-images.githubusercontent.com/1778222/67737138-1ad61280-f9d8-11e9-99d8-ecc43cbc349e.jpg)
