### PR TITLE
Add Leadership video blocks to article pages

### DIFF
--- a/packages/common/components/blocks/leadership-company-videos.marko
+++ b/packages/common/components/blocks/leadership-company-videos.marko
@@ -1,0 +1,34 @@
+import { get, getAsArray } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/leadership-company-videos";
+
+$ const { contentId } = input;
+
+<marko-web-query|{ nodes }|
+  name="related-published-content"
+  params={ contentId, limit: 20, queryFragment, includeContentTypes: ["Company"] }
+>
+  <if(nodes.length)>
+    <for|company| of=nodes>
+      <if(company.isLeader)>
+        $ const videos = getAsArray(company, "videos.edges").map(({ node }) => node);
+        <if(videos.length)>
+          <marko-web-node-list class="mt-block" collapsible=false>
+            <@header>
+              Videos from ${company.name}
+              <a target="_blank" href=get(company, "youtube.url") rel="noopener" class="small float-right py-1">
+                View all videos
+              </a>
+            </@header>
+            <@body>
+              <default-theme-card-deck-flow cols=3 nodes=videos>
+                <@slot|{ node, index }|>
+                  <common-youtube-card-node node=node />
+                </@slot>
+              </default-theme-card-deck-flow>
+            </@body>
+          </marko-web-node-list>
+        </if>
+      </if>
+    </for>
+  </if>
+</marko-web-query>

--- a/packages/common/components/blocks/leadership-company-videos.marko
+++ b/packages/common/components/blocks/leadership-company-videos.marko
@@ -13,11 +13,11 @@ $ const { contentId } = input;
         $ const videos = getAsArray(company, "videos.edges").map(({ node }) => node);
         <if(videos.length)>
           <marko-web-node-list class="mt-block" collapsible=false>
-            <@header>
-              Videos from ${company.name}
-              <a target="_blank" href=get(company, "youtube.url") rel="noopener" class="small float-right py-1">
+            <@header modifiers=["leadership-company-videos"]>
+              <span>Videos from ${company.name}</span>
+              <marko-web-link target="_blank" href=get(company, "youtube.url")>
                 View all videos
-              </a>
+              </marko-web-link>
             </@header>
             <@body>
               <default-theme-card-deck-flow cols=3 nodes=videos>

--- a/packages/common/components/blocks/marko.json
+++ b/packages/common/components/blocks/marko.json
@@ -10,6 +10,13 @@
     "common-company-details": {
       "template": "./company-details.marko",
       "@company": "object"
+    },
+    "common-leadership-company-videos": {
+      "template": "./leadership-company-videos.marko",
+      "@content-id": {
+        "type": "number",
+        "required": true
+      }
     }
   }
 }

--- a/packages/common/graphql/fragments/leadership-company-videos.js
+++ b/packages/common/graphql/fragments/leadership-company-videos.js
@@ -1,0 +1,30 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment LeadershipCompanyVideosFragment on Content {
+  id
+  name
+  siteContext {
+    path
+  }
+  ... on ContentCompany {
+    isLeader: hasWebsiteSchedule(input: { sectionAlias: "leaders" })
+    youtube {
+      url
+    }
+    videos: youtubeVideos(input: { pagination: { limit: 3 } }) {
+      edges {
+        node {
+          id
+          url
+          title
+          published
+          thumbnail(input: { size: high })
+        }
+      }
+    }
+  }
+}
+
+`;

--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -108,6 +108,16 @@ $leaders-label-color: $gray-600;
 
 .node-list {
   $self: &;
+  &__header {
+    &--leadership-company-videos {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      a {
+        font-size: .8rem;
+      }
+    }
+  }
   &__header,
   &__body {
     &--centered {

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -130,7 +130,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         </@section>
       </marko-web-page-wrapper>
 
-      <!-- @todo Videos from [Company Name] block, if company and content.isLeader -->
+      <if(["article", "blog", "news", "press-release"].includes(content.type))>
+        <common-leadership-company-videos content-id=content.id />
+      </if>
 
       <div class="row mt-4">
         <div class="col-lg-8">

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -130,7 +130,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         </@section>
       </marko-web-page-wrapper>
 
-      <!-- @todo Videos from [Company Name] block, if company and content.isLeader -->
+      <if(["article", "blog", "news", "press-release"].includes(content.type))>
+        <common-leadership-company-videos content-id=content.id />
+      </if>
 
       <div class="row mt-4">
         <div class="col-lg-8">

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -130,7 +130,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         </@section>
       </marko-web-page-wrapper>
 
-      <!-- @todo Videos from [Company Name] block, if company and content.isLeader -->
+      <if(["article", "blog", "news", "press-release"].includes(content.type))>
+        <common-leadership-company-videos content-id=content.id />
+      </if>
 
       <div class="row mt-4">
         <div class="col-lg-8">

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -130,7 +130,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         </@section>
       </marko-web-page-wrapper>
 
-      <!-- @todo Videos from [Company Name] block, if company and content.isLeader -->
+      <if(["article", "blog", "news", "press-release"].includes(content.type))>
+        <common-leadership-company-videos content-id=content.id />
+      </if>
 
       <div class="row mt-4">
         <div class="col-lg-8">

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -130,7 +130,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         </@section>
       </marko-web-page-wrapper>
 
-      <!-- @todo Videos from [Company Name] block, if company and content.isLeader -->
+      <if(["article", "blog", "news", "press-release"].includes(content.type))>
+        <common-leadership-company-videos content-id=content.id />
+      </if>
 
       <div class="row mt-4">
         <div class="col-lg-8">


### PR DESCRIPTION
For each related company on a content document, if the company is a leader, display a block listing their 3 latest videos.

Ref design 
https://sketch.cloud/s/nVbpW/a/Jal2v9

Screenshot
![screencapture-0-0-0-0-9710-products-networks-article-13320089-nokia-employs-5g-in-its-own-factory-2019-10-29-12_35_11](https://user-images.githubusercontent.com/1778222/67793675-48a76f80-fa49-11e9-9bd8-77b5e1671024.jpg)
