### PR TITLE
Add image carousel to PMMI's standard content pages

### DIFF
--- a/packages/common/browser/image-slide.vue
+++ b/packages/common/browser/image-slide.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="carousel-item" :class="classNames">
+    <img :src="image.src" :alt="image.alt">
+    <div class="carousel-caption">
+      <h5 v-if="image.displayName">
+        {{ image.displayName }}
+      </h5>
+      <p v-if="image.caption">
+        {{ image.caption }}
+      </p>
+      <p v-if="image.credit">
+        {{ image.credit }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    activeIndex: {
+      type: Number,
+      required: true,
+    },
+    index: {
+      type: Number,
+      required: true,
+    },
+    length: {
+      type: Number,
+      required: true,
+    },
+    image: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    classNames() {
+      const { activeIndex, index, length } = this;
+      const prevIdx = activeIndex - 1 < 0 ? activeIndex : activeIndex - 1;
+      const nextIdx = activeIndex + 1 >= length ? activeIndex : activeIndex + 1;
+      const active = index === activeIndex;
+      const carouselItemLeft = index === prevIdx && activeIndex !== index;
+      const carouselItemRight = index === nextIdx && activeIndex !== index;
+      return {
+        active,
+        'carousel-item-prev': carouselItemLeft,
+        'carousel-item-next': carouselItemRight,
+      };
+    },
+  },
+};
+</script>

--- a/packages/common/browser/image-slider.vue
+++ b/packages/common/browser/image-slider.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="carousel">
+    <ol class="carousel-indicators">
+      <li
+        v-for="(image, index) in images"
+        :key="index"
+        :class="{ active: index === activeIndex }"
+        @click="set(index)"
+      />
+    </ol>
+    <div class="carousel-inner">
+      <ImageSlide
+        v-for="(image, index) in images"
+        :key="index"
+        :length="images.length"
+        :index="index"
+        :image="image"
+        :active-index="activeIndex"
+      />
+    </div>
+    <a
+      href="#previous-slide"
+      class="carousel-control-prev"
+      role="button"
+      @click="decrement"
+    >
+      <span class="carousel-control-prev-icon" aria-label="Previous Slide" aria-hidden="true" />
+    </a>
+    <a
+      href="#next-slide"
+      class="carousel-control-next"
+      role="button"
+      @click="increment"
+    >
+      <span class="carousel-control-next-icon" aria-label="Next Slide" aria-hidden="true" />
+    </a>
+  </div>
+</template>
+
+<script>
+import ImageSlide from './image-slide.vue';
+
+export default {
+  components: {
+    ImageSlide,
+  },
+  props: {
+    images: {
+      type: Array,
+      required: true,
+    },
+  },
+  data: () => ({
+    activeIndex: 0,
+  }),
+  methods: {
+    set(index) {
+      this.activeIndex = index;
+    },
+    increment() {
+      const { activeIndex } = this;
+      const { length } = this.images;
+      this.activeIndex = (activeIndex + 1 >= length) ? activeIndex : activeIndex + 1;
+    },
+    decrement() {
+      const { activeIndex } = this;
+      this.activeIndex = (activeIndex - 1 < 0) ? activeIndex : activeIndex - 1;
+    },
+  },
+};
+</script>

--- a/packages/common/browser/index.js
+++ b/packages/common/browser/index.js
@@ -1,10 +1,12 @@
 import ContactUsForm from './contact-us-form.vue';
+import ImageSlider from './image-slider.vue';
 import LeadersItem from '../leaders/browser/item.vue';
 import LeadersItemStatic from '../leaders/browser/item-static.vue';
 
 export default (Browser) => {
   // @todo this should be removed once contact us is moved to core.
   Browser.registerComponent('CommonContactUsForm', ContactUsForm);
+  Browser.registerComponent('CommonImageSlider', ImageSlider);
   Browser.registerComponent('CommonLeadersItem', LeadersItem);
   Browser.registerComponent('CommonLeadersItemStatic', LeadersItemStatic);
 };

--- a/packages/common/components/elements/image-slider.marko
+++ b/packages/common/components/elements/image-slider.marko
@@ -1,0 +1,20 @@
+import { getAsArray } from '@base-cms/object-path';
+import { buildImgixUrl } from "@base-cms/image";
+
+$ const imageOptions = {
+  ar: '16:9',
+  fit: 'crop',
+  crop: 'focalpoint',
+  fpX: 0.5,
+  fpY: 0.5,
+  w: 1140,
+};
+$ const images = getAsArray(input, 'images').map(node => {
+  const isLogo = Boolean(node.isLogo);
+  const src = buildImgixUrl(node.src, imageOptions, imageOptions, isLogo);
+  return { ...node, src };
+});
+
+<if(images.length)>
+  <marko-web-browser-component name="CommonImageSlider" props={ images } />
+</if>

--- a/packages/common/components/elements/marko.json
+++ b/packages/common/components/elements/marko.json
@@ -3,6 +3,9 @@
     "common-company-logo": {
       "template": "./company-logo.marko",
       "@content": "object"
+    },
+    "common-image-slider": {
+      "template": "./image-slider.marko"
     }
   }
 }

--- a/packages/common/scss/carousel.scss
+++ b/packages/common/scss/carousel.scss
@@ -1,0 +1,46 @@
+@import "../../node_modules/bootstrap/scss/carousel";
+
+$theme-carousel-caption-padding: 1rem !default;
+$theme-carousel-caption-text-shadow: gba(0, 0, 0, .6) 0 1px 2px !default;
+$theme-carousel-caption-background: rgba(0, 0, 0, .75) !default;
+
+.carousel {
+  margin-bottom: $breadcrumb-padding-y;
+
+  .carousel-item {
+    img {
+      display: block;
+      width: 100%;
+    }
+  }
+
+  .carousel-caption {
+    right: 0;
+    bottom: 0;
+    left: 0;
+    padding-bottom: $theme-carousel-caption-padding;
+    text-shadow: $theme-carousel-caption-text-shadow;
+    background: $theme-carousel-caption-background;
+    p {
+      display: none;
+      @include media-breakpoint-up(md) {
+        display: block;
+      }
+    }
+  }
+
+  .carousel-indicators {
+    margin-bottom: 0;
+  }
+}
+
+// Carousel Overrides
+
+.carousel-control-next,
+.carousel-control-prev {
+  top: initial;
+  bottom: 8px;
+  z-index: 16;
+  justify-content: space-around;
+  opacity: initial;
+}

--- a/packages/common/scss/common.scss
+++ b/packages/common/scss/common.scss
@@ -1,5 +1,6 @@
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/orion/skin";
 @import "../../node_modules/@base-cms/marko-web-gtm/scss/slot";
+@import "./carousel";
 @import "./contact-us-form"; // @todo this should be remove once contact us is in core
 @import "./company-page";
 @import "./leaders";

--- a/sites/automationworld/server/graphql/fragments/content-page.js
+++ b/sites/automationworld/server/graphql/fragments/content-page.js
@@ -42,6 +42,19 @@ fragment ContentPageFragment on Content {
     credit
     isLogo
   }
+  images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
+    edges {
+      node {
+        id
+        src
+        alt
+        displayName
+        caption
+        credit
+        isLogo
+      }
+    }
+  }
   gating {
     surveyType
     surveyId
@@ -138,20 +151,6 @@ fragment ContentPageFragment on Content {
           siteContext {
             path
           }
-        }
-      }
-    }
-  }
-  ... on ContentMediaGallery {
-    images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
-      edges {
-        node {
-          id
-          src
-          alt
-          displayName
-          caption
-          credit
         }
       }
     }

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -67,7 +67,23 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
-                <common-image-slider images=images />
+                <if(images.length > 1)>
+                  <common-image-slider images=images />
+                </if>
+                <else>
+                  $ const isLogo = get(content, "primaryImage.isLogo");
+                  <if(isLogo)>
+                    <marko-web-page-image
+                      modifiers=["primary-image-inline"]
+                      obj=content.primaryImage
+                      fluid=false
+                      width=250
+                    />
+                  </if>
+                  <else>
+                    <marko-web-page-image width=500 obj=content.primaryImage />
+                  </else>
+                </else>
               </else-if>
               <else-if(type === "contact")>
                 <marko-web-page-image width=300 fluid=false obj=content.primaryImage />

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -6,7 +6,7 @@ import GAM from "../../../config/gam";
 $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
-$ const displayPrimaryImage = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
+$ const displayCarousel = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
 $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? false : true;
 
 <marko-web-content-page-layout id=id type=type>
@@ -65,19 +65,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <if(content.embedCode)>
                 <marko-web-content-embed-code block-name=blockName obj=content />
               </if>
-              <else-if(displayPrimaryImage)>
-                $ const isLogo = get(content, "primaryImage.isLogo");
-                <if(isLogo)>
-                  <marko-web-page-image
-                    modifiers=["primary-image-inline"]
-                    obj=content.primaryImage
-                    fluid=false
-                    width=250
-                  />
-                </if>
-                <else>
-                  <marko-web-page-image width=500 obj=content.primaryImage />
-                </else>
+              <else-if(displayCarousel)>
+                $ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
+                <common-image-slider images=images />
               </else-if>
               <else-if(type === "contact")>
                 <marko-web-page-image width=300 fluid=false obj=content.primaryImage />

--- a/sites/healthcarepackaging/server/graphql/fragments/content-page.js
+++ b/sites/healthcarepackaging/server/graphql/fragments/content-page.js
@@ -42,6 +42,18 @@ fragment ContentPageFragment on Content {
     credit
     isLogo
   }
+  images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
+    edges {
+      node {
+        id
+        src
+        alt
+        displayName
+        caption
+        credit
+      }
+    }
+  }
   gating {
     surveyType
     surveyId
@@ -138,20 +150,6 @@ fragment ContentPageFragment on Content {
           siteContext {
             path
           }
-        }
-      }
-    }
-  }
-  ... on ContentMediaGallery {
-    images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
-      edges {
-        node {
-          id
-          src
-          alt
-          displayName
-          caption
-          credit
         }
       }
     }

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -6,7 +6,7 @@ import GAM from "../../../config/gam";
 $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
-$ const displayPrimaryImage = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
+$ const displayCarousel = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
 $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? false : true;
 
 <marko-web-content-page-layout id=id type=type>
@@ -65,18 +65,24 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <if(content.embedCode)>
                 <marko-web-content-embed-code block-name=blockName obj=content />
               </if>
-              <else-if(displayPrimaryImage)>
-                $ const isLogo = get(content, "primaryImage.isLogo");
-                <if(isLogo)>
-                  <marko-web-page-image
-                    modifiers=["primary-image-inline"]
-                    obj=content.primaryImage
-                    fluid=false
-                    width=250
-                  />
+              <else-if(displayCarousel)>
+                $ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
+                <if(images.length > 1)>
+                  <common-image-slider images=images />
                 </if>
                 <else>
-                  <marko-web-page-image width=500 obj=content.primaryImage />
+                  $ const isLogo = get(content, "primaryImage.isLogo");
+                  <if(isLogo)>
+                    <marko-web-page-image
+                      modifiers=["primary-image-inline"]
+                      obj=content.primaryImage
+                      fluid=false
+                      width=250
+                    />
+                  </if>
+                  <else>
+                    <marko-web-page-image width=500 obj=content.primaryImage />
+                  </else>
                 </else>
               </else-if>
               <else-if(type === "contact")>

--- a/sites/oemmagazine/server/graphql/fragments/content-page.js
+++ b/sites/oemmagazine/server/graphql/fragments/content-page.js
@@ -42,6 +42,18 @@ fragment ContentPageFragment on Content {
     credit
     isLogo
   }
+  images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
+    edges {
+      node {
+        id
+        src
+        alt
+        displayName
+        caption
+        credit
+      }
+    }
+  }
   gating {
     surveyType
     surveyId
@@ -138,20 +150,6 @@ fragment ContentPageFragment on Content {
           siteContext {
             path
           }
-        }
-      }
-    }
-  }
-  ... on ContentMediaGallery {
-    images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
-      edges {
-        node {
-          id
-          src
-          alt
-          displayName
-          caption
-          credit
         }
       }
     }

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -6,7 +6,7 @@ import GAM from "../../../config/gam";
 $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
-$ const displayPrimaryImage = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
+$ const displayCarousel = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
 $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? false : true;
 
 <marko-web-content-page-layout id=id type=type>
@@ -65,18 +65,24 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <if(content.embedCode)>
                 <marko-web-content-embed-code block-name=blockName obj=content />
               </if>
-              <else-if(displayPrimaryImage)>
-                $ const isLogo = get(content, "primaryImage.isLogo");
-                <if(isLogo)>
-                  <marko-web-page-image
-                    modifiers=["primary-image-inline"]
-                    obj=content.primaryImage
-                    fluid=false
-                    width=250
-                  />
+              <else-if(displayCarousel)>
+                $ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
+                <if(images.length > 1)>
+                  <common-image-slider images=images />
                 </if>
                 <else>
-                  <marko-web-page-image width=500 obj=content.primaryImage />
+                  $ const isLogo = get(content, "primaryImage.isLogo");
+                  <if(isLogo)>
+                    <marko-web-page-image
+                      modifiers=["primary-image-inline"]
+                      obj=content.primaryImage
+                      fluid=false
+                      width=250
+                    />
+                  </if>
+                  <else>
+                    <marko-web-page-image width=500 obj=content.primaryImage />
+                  </else>
                 </else>
               </else-if>
               <else-if(type === "contact")>

--- a/sites/packworld/server/graphql/fragments/content-page.js
+++ b/sites/packworld/server/graphql/fragments/content-page.js
@@ -42,6 +42,18 @@ fragment ContentPageFragment on Content {
     credit
     isLogo
   }
+  images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
+    edges {
+      node {
+        id
+        src
+        alt
+        displayName
+        caption
+        credit
+      }
+    }
+  }
   gating {
     surveyType
     surveyId
@@ -138,20 +150,6 @@ fragment ContentPageFragment on Content {
           siteContext {
             path
           }
-        }
-      }
-    }
-  }
-  ... on ContentMediaGallery {
-    images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
-      edges {
-        node {
-          id
-          src
-          alt
-          displayName
-          caption
-          credit
         }
       }
     }

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -6,7 +6,7 @@ import GAM from "../../../config/gam";
 $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
-$ const displayPrimaryImage = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
+$ const displayCarousel = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
 $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? false : true;
 
 <marko-web-content-page-layout id=id type=type>
@@ -65,18 +65,24 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <if(content.embedCode)>
                 <marko-web-content-embed-code block-name=blockName obj=content />
               </if>
-              <else-if(displayPrimaryImage)>
-                $ const isLogo = get(content, "primaryImage.isLogo");
-                <if(isLogo)>
-                  <marko-web-page-image
-                    modifiers=["primary-image-inline"]
-                    obj=content.primaryImage
-                    fluid=false
-                    width=250
-                  />
+              <else-if(displayCarousel)>
+                $ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
+                <if(images.length > 1)>
+                  <common-image-slider images=images />
                 </if>
                 <else>
-                  <marko-web-page-image width=500 obj=content.primaryImage />
+                  $ const isLogo = get(content, "primaryImage.isLogo");
+                  <if(isLogo)>
+                    <marko-web-page-image
+                      modifiers=["primary-image-inline"]
+                      obj=content.primaryImage
+                      fluid=false
+                      width=250
+                    />
+                  </if>
+                  <else>
+                    <marko-web-page-image width=500 obj=content.primaryImage />
+                  </else>
                 </else>
               </else-if>
               <else-if(type === "contact")>

--- a/sites/profoodworld/server/graphql/fragments/content-page.js
+++ b/sites/profoodworld/server/graphql/fragments/content-page.js
@@ -42,6 +42,18 @@ fragment ContentPageFragment on Content {
     credit
     isLogo
   }
+  images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
+    edges {
+      node {
+        id
+        src
+        alt
+        displayName
+        caption
+        credit
+      }
+    }
+  }
   gating {
     surveyType
     surveyId
@@ -138,20 +150,6 @@ fragment ContentPageFragment on Content {
           siteContext {
             path
           }
-        }
-      }
-    }
-  }
-  ... on ContentMediaGallery {
-    images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
-      edges {
-        node {
-          id
-          src
-          alt
-          displayName
-          caption
-          credit
         }
       }
     }

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -6,7 +6,7 @@ import GAM from "../../../config/gam";
 $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
-$ const displayPrimaryImage = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
+$ const displayCarousel = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
 $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? false : true;
 
 <marko-web-content-page-layout id=id type=type>
@@ -65,18 +65,24 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <if(content.embedCode)>
                 <marko-web-content-embed-code block-name=blockName obj=content />
               </if>
-              <else-if(displayPrimaryImage)>
-                $ const isLogo = get(content, "primaryImage.isLogo");
-                <if(isLogo)>
-                  <marko-web-page-image
-                    modifiers=["primary-image-inline"]
-                    obj=content.primaryImage
-                    fluid=false
-                    width=250
-                  />
+              <else-if(displayCarousel)>
+                $ const images = getAsArray(content, 'images.edges').map(({ node }) => node);
+                <if(images.length > 1)>
+                  <common-image-slider images=images />
                 </if>
                 <else>
-                  <marko-web-page-image width=500 obj=content.primaryImage />
+                  $ const isLogo = get(content, "primaryImage.isLogo");
+                  <if(isLogo)>
+                    <marko-web-page-image
+                      modifiers=["primary-image-inline"]
+                      obj=content.primaryImage
+                      fluid=false
+                      width=250
+                    />
+                  </if>
+                  <else>
+                    <marko-web-page-image width=500 obj=content.primaryImage />
+                  </else>
                 </else>
               </else-if>
               <else-if(type === "contact")>


### PR DESCRIPTION
 - Added common image slider Vue & Marko components
 - Added Images to be return on all content not just MediaGalleries in the content-page query fragment

![Screen Shot 2019-10-29 at 3 52 48 PM](https://user-images.githubusercontent.com/3845869/67808785-4ce18600-fa65-11e9-99c8-5cda1181e576.png)
