### PR TITLE
Custom redirect handlers for all sites

### DIFF
--- a/sites/automationworld/index.js
+++ b/sites/automationworld/index.js
@@ -7,6 +7,7 @@ const coreConfig = require('./config/core');
 const document = require('./server/components/document');
 const components = require('./server/components');
 const fragments = require('./server/fragments');
+const redirectHandler = require('./redirect-handler');
 
 const { log } = console;
 
@@ -21,4 +22,5 @@ module.exports = startServer({
   version,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
+  redirectHandler,
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/automationworld/redirect-handler.js
+++ b/sites/automationworld/redirect-handler.js
@@ -1,4 +1,4 @@
-const digital = async (from) => {
+const digital = (from) => {
   const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -7,7 +7,7 @@ const digital = async (from) => {
   return null;
 };
 
-const s3 = async (from) => {
+const s3 = (from) => {
   const pattern = /\/sites\/default\/files\/(.*)/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -16,4 +16,12 @@ const s3 = async (from) => {
   return null;
 };
 
-module.exports = async ({ from }) => Promise.all([digital(from), s3(from)]).then(l => l[0]);
+module.exports = ({ from }) => {
+  const digitalRedirect = digital(from);
+  if (digitalRedirect) return digitalRedirect;
+
+  const s3Redirect = s3(from);
+  if (s3Redirect) return s3Redirect;
+
+  return null;
+};

--- a/sites/automationworld/redirect-handler.js
+++ b/sites/automationworld/redirect-handler.js
@@ -1,15 +1,11 @@
-const redirect = (from, pattern) => pattern.exec(from);
+const exec = (from, pattern) => pattern.exec(from);
 
 module.exports = ({ from }) => {
-  const digital = redirect(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
-  if (digital && digital[1]) {
-    return { to: `https://digitaleditions.automationworld.com/${digital[1]}` };
-  }
+  const digital = exec(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
+  if (digital && digital[1]) return { to: `https://digitaleditions.automationworld.com/${digital[1]}` };
 
-  const s3 = redirect(from, /\/sites\/default\/files\/(.*)/);
-  if (s3 && s3[1]) {
-    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/AW/${s3[1]}` };
-  }
+  const s3 = exec(from, /\/sites\/default\/files\/(.*)/);
+  if (s3 && s3[1]) return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/AW/${s3[1]}` };
 
   return null;
 };

--- a/sites/automationworld/redirect-handler.js
+++ b/sites/automationworld/redirect-handler.js
@@ -1,0 +1,19 @@
+const digital = async (from) => {
+  const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://digitaleditions.automationworld.com/${matches[1]}` };
+  }
+  return null;
+};
+
+const s3 = async (from) => {
+  const pattern = /\/sites\/default\/files\/(.*)/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/AW/${matches[1]}` };
+  }
+  return null;
+};
+
+module.exports = async ({ from }) => Promise.all([digital(from), s3(from)]).then(l => l[0]);

--- a/sites/automationworld/redirect-handler.js
+++ b/sites/automationworld/redirect-handler.js
@@ -1,27 +1,15 @@
-const digital = (from) => {
-  const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
-    return { to: `https://digitaleditions.automationworld.com/${matches[1]}` };
-  }
-  return null;
-};
-
-const s3 = (from) => {
-  const pattern = /\/sites\/default\/files\/(.*)/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
-    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/AW/${matches[1]}` };
-  }
-  return null;
-};
+const redirect = (from, pattern) => pattern.exec(from);
 
 module.exports = ({ from }) => {
-  const digitalRedirect = digital(from);
-  if (digitalRedirect) return digitalRedirect;
+  const digital = redirect(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
+  if (digital && digital[1]) {
+    return { to: `https://digitaleditions.automationworld.com/${digital[1]}` };
+  }
 
-  const s3Redirect = s3(from);
-  if (s3Redirect) return s3Redirect;
+  const s3 = redirect(from, /\/sites\/default\/files\/(.*)/);
+  if (s3 && s3[1]) {
+    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/AW/${s3[1]}` };
+  }
 
   return null;
 };

--- a/sites/healthcarepackaging/index.js
+++ b/sites/healthcarepackaging/index.js
@@ -7,6 +7,7 @@ const coreConfig = require('./config/core');
 const document = require('./server/components/document');
 const components = require('./server/components');
 const fragments = require('./server/fragments');
+const redirectHandler = require('./redirect-handler');
 
 const { log } = console;
 
@@ -21,4 +22,5 @@ module.exports = startServer({
   version,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
+  redirectHandler,
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/healthcarepackaging/redirect-handler.js
+++ b/sites/healthcarepackaging/redirect-handler.js
@@ -1,15 +1,11 @@
-const redirect = (from, pattern) => pattern.exec(from);
+const exec = (from, pattern) => pattern.exec(from);
 
 module.exports = ({ from }) => {
-  const digital = redirect(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
-  if (digital && digital[1]) {
-    return { to: `https://digitaleditions.healthcarepackaging.com/${digital[1]}` };
-  }
+  const digital = exec(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
+  if (digital && digital[1]) return { to: `https://digitaleditions.healthcarepackaging.com/${digital[1]}` };
 
-  const s3 = redirect(from, /\/sites\/default\/files\/(.*)/);
-  if (s3 && s3[1]) {
-    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/HCP/${s3[1]}` };
-  }
+  const s3 = exec(from, /\/sites\/default\/files\/(.*)/);
+  if (s3 && s3[1]) return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/HCP/${s3[1]}` };
 
   return null;
 };

--- a/sites/healthcarepackaging/redirect-handler.js
+++ b/sites/healthcarepackaging/redirect-handler.js
@@ -1,4 +1,4 @@
-const digital = async (from) => {
+const digital = (from) => {
   const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -7,7 +7,7 @@ const digital = async (from) => {
   return null;
 };
 
-const s3 = async (from) => {
+const s3 = (from) => {
   const pattern = /\/sites\/default\/files\/(.*)/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -16,4 +16,12 @@ const s3 = async (from) => {
   return null;
 };
 
-module.exports = async ({ from }) => Promise.all([digital(from), s3(from)]).then(l => l[0]);
+module.exports = ({ from }) => {
+  const digitalRedirect = digital(from);
+  if (digitalRedirect) return digitalRedirect;
+
+  const s3Redirect = s3(from);
+  if (s3Redirect) return s3Redirect;
+
+  return null;
+};

--- a/sites/healthcarepackaging/redirect-handler.js
+++ b/sites/healthcarepackaging/redirect-handler.js
@@ -1,0 +1,19 @@
+const digital = async (from) => {
+  const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://digitaleditions.healthcarepackaging.com/${matches[1]}` };
+  }
+  return null;
+};
+
+const s3 = async (from) => {
+  const pattern = /\/sites\/default\/files\/(.*)/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/HCP/${matches[1]}` };
+  }
+  return null;
+};
+
+module.exports = async ({ from }) => Promise.all([digital(from), s3(from)]).then(l => l[0]);

--- a/sites/healthcarepackaging/redirect-handler.js
+++ b/sites/healthcarepackaging/redirect-handler.js
@@ -1,27 +1,15 @@
-const digital = (from) => {
-  const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
-    return { to: `https://digitaleditions.healthcarepackaging.com/${matches[1]}` };
-  }
-  return null;
-};
-
-const s3 = (from) => {
-  const pattern = /\/sites\/default\/files\/(.*)/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
-    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/HCP/${matches[1]}` };
-  }
-  return null;
-};
+const redirect = (from, pattern) => pattern.exec(from);
 
 module.exports = ({ from }) => {
-  const digitalRedirect = digital(from);
-  if (digitalRedirect) return digitalRedirect;
+  const digital = redirect(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
+  if (digital && digital[1]) {
+    return { to: `https://digitaleditions.healthcarepackaging.com/${digital[1]}` };
+  }
 
-  const s3Redirect = s3(from);
-  if (s3Redirect) return s3Redirect;
+  const s3 = redirect(from, /\/sites\/default\/files\/(.*)/);
+  if (s3 && s3[1]) {
+    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/HCP/${s3[1]}` };
+  }
 
   return null;
 };

--- a/sites/oemmagazine/index.js
+++ b/sites/oemmagazine/index.js
@@ -7,6 +7,7 @@ const coreConfig = require('./config/core');
 const document = require('./server/components/document');
 const components = require('./server/components');
 const fragments = require('./server/fragments');
+const redirectHandler = require('./redirect-handler');
 
 const { log } = console;
 
@@ -21,4 +22,5 @@ module.exports = startServer({
   version,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
+  redirectHandler,
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/oemmagazine/redirect-handler.js
+++ b/sites/oemmagazine/redirect-handler.js
@@ -1,27 +1,15 @@
-const digital = (from) => {
-  const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
-    return { to: `https://digitaleditions.oemmagazine.org/${matches[1]}` };
-  }
-  return null;
-};
-
-const s3 = (from) => {
-  const pattern = /\/sites\/default\/files\/(.*)/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
-    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/OEM/${matches[1]}` };
-  }
-  return null;
-};
+const redirect = (from, pattern) => pattern.exec(from);
 
 module.exports = ({ from }) => {
-  const digitalRedirect = digital(from);
-  if (digitalRedirect) return digitalRedirect;
+  const digital = redirect(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
+  if (digital && digital[1]) {
+    return { to: `https://digitaleditions.oemmagazine.org/${digital[1]}` };
+  }
 
-  const s3Redirect = s3(from);
-  if (s3Redirect) return s3Redirect;
+  const s3 = redirect(from, /\/sites\/default\/files\/(.*)/);
+  if (s3 && s3[1]) {
+    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/OEM/${s3[1]}` };
+  }
 
   return null;
 };

--- a/sites/oemmagazine/redirect-handler.js
+++ b/sites/oemmagazine/redirect-handler.js
@@ -1,15 +1,11 @@
-const redirect = (from, pattern) => pattern.exec(from);
+const exec = (from, pattern) => pattern.exec(from);
 
 module.exports = ({ from }) => {
-  const digital = redirect(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
-  if (digital && digital[1]) {
-    return { to: `https://digitaleditions.oemmagazine.org/${digital[1]}` };
-  }
+  const digital = exec(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
+  if (digital && digital[1]) return { to: `https://digitaleditions.oemmagazine.org/${digital[1]}` };
 
-  const s3 = redirect(from, /\/sites\/default\/files\/(.*)/);
-  if (s3 && s3[1]) {
-    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/OEM/${s3[1]}` };
-  }
+  const s3 = exec(from, /\/sites\/default\/files\/(.*)/);
+  if (s3 && s3[1]) return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/OEM/${s3[1]}` };
 
   return null;
 };

--- a/sites/oemmagazine/redirect-handler.js
+++ b/sites/oemmagazine/redirect-handler.js
@@ -1,4 +1,4 @@
-const digital = async (from) => {
+const digital = (from) => {
   const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -7,7 +7,7 @@ const digital = async (from) => {
   return null;
 };
 
-const s3 = async (from) => {
+const s3 = (from) => {
   const pattern = /\/sites\/default\/files\/(.*)/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -16,4 +16,12 @@ const s3 = async (from) => {
   return null;
 };
 
-module.exports = async ({ from }) => Promise.all([digital(from), s3(from)]).then(l => l[0]);
+module.exports = ({ from }) => {
+  const digitalRedirect = digital(from);
+  if (digitalRedirect) return digitalRedirect;
+
+  const s3Redirect = s3(from);
+  if (s3Redirect) return s3Redirect;
+
+  return null;
+};

--- a/sites/oemmagazine/redirect-handler.js
+++ b/sites/oemmagazine/redirect-handler.js
@@ -1,0 +1,19 @@
+const digital = async (from) => {
+  const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://digitaleditions.oemmagazine.org/${matches[1]}` };
+  }
+  return null;
+};
+
+const s3 = async (from) => {
+  const pattern = /\/sites\/default\/files\/(.*)/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/OEM/${matches[1]}` };
+  }
+  return null;
+};
+
+module.exports = async ({ from }) => Promise.all([digital(from), s3(from)]).then(l => l[0]);

--- a/sites/packworld/index.js
+++ b/sites/packworld/index.js
@@ -7,6 +7,7 @@ const coreConfig = require('./config/core');
 const document = require('./server/components/document');
 const components = require('./server/components');
 const fragments = require('./server/fragments');
+const redirectHandler = require('./redirect-handler');
 
 const { log } = console;
 
@@ -21,4 +22,5 @@ module.exports = startServer({
   version,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
+  redirectHandler,
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/packworld/redirect-handler.js
+++ b/sites/packworld/redirect-handler.js
@@ -1,30 +1,20 @@
-const redirect = (from, pattern) => pattern.exec(from);
+const exec = (from, pattern) => pattern.exec(from);
 
 module.exports = ({ from }) => {
-  const digital = redirect(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
-  if (digital && digital[1]) {
-    return { to: `https://digitaleditions.packworld.com/${digital[1]}` };
-  }
+  const digital = exec(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
+  if (digital && digital[1]) return { to: `https://digitaleditions.packworld.com/${digital[1]}` };
 
-  const s3 = redirect(from, /\/sites\/default\/files\/(.*)/);
-  if (s3 && s3[1]) {
-    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/AW/${s3[1]}` };
-  }
+  const s3 = exec(from, /\/sites\/default\/files\/(.*)/);
+  if (s3 && s3[1]) return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/AW/${s3[1]}` };
 
-  const showcase = redirect(from, /^\/showcasesubmit/);
-  if (showcase && showcase[1]) {
-    return { to: 'https://showcasesubmit.packworld.com' };
-  }
+  const showcase = exec(from, /^\/showcasesubmit/);
+  if (showcase && showcase[1]) return { to: 'https://showcasesubmit.packworld.com' };
 
-  const mundoHome = redirect(from, /^\/mundopmmi$/);
-  if (mundoHome && mundoHome[1]) {
-    return { to: 'https://www.mundopmmi.com' };
-  }
+  const mundoHome = exec(from, /^\/mundopmmi$/);
+  if (mundoHome && mundoHome[1]) return { to: 'https://www.mundopmmi.com' };
 
-  const mundo = redirect(from, /^\/mundopmmi\/.*/);
-  if (mundo && mundo[1]) {
-    return { to: `https://www.mundopmmi.com${from}` };
-  }
+  const mundo = exec(from, /^\/mundopmmi\/.*/);
+  if (mundo && mundo[1]) return { to: `https://www.mundopmmi.com${from}` };
 
   return null;
 };

--- a/sites/packworld/redirect-handler.js
+++ b/sites/packworld/redirect-handler.js
@@ -1,74 +1,30 @@
-const digital = (from) => {
-  const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
-    return { to: `https://digitaleditions.packworld.com/${matches[1]}` };
-  }
-  return null;
-};
+const redirect = (from, pattern) => pattern.exec(from);
 
-const s3 = (from) => {
-  const pattern = /\/sites\/default\/files\/(.*)/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
-    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/PW/${matches[1]}` };
+module.exports = ({ from }) => {
+  const digital = redirect(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
+  if (digital && digital[1]) {
+    return { to: `https://digitaleditions.packworld.com/${digital[1]}` };
   }
-  return null;
-};
 
-const showcase = (from) => {
-  const pattern = /^\/showcasesubmit/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
+  const s3 = redirect(from, /\/sites\/default\/files\/(.*)/);
+  if (s3 && s3[1]) {
+    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/AW/${s3[1]}` };
+  }
+
+  const showcase = redirect(from, /^\/showcasesubmit/);
+  if (showcase && showcase[1]) {
     return { to: 'https://showcasesubmit.packworld.com' };
   }
-  return null;
-};
 
-const mundoHome = (from) => {
-  const pattern = /^\/mundopmmi$/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
+  const mundoHome = redirect(from, /^\/mundopmmi$/);
+  if (mundoHome && mundoHome[1]) {
     return { to: 'https://www.mundopmmi.com' };
   }
-  return null;
-};
 
-const mundo = (from) => {
-  const pattern = /^\/mundopmmi\/.*/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
+  const mundo = redirect(from, /^\/mundopmmi\/.*/);
+  if (mundo && mundo[1]) {
     return { to: `https://www.mundopmmi.com${from}` };
   }
-  return null;
-};
-
-module.exports = ({ from }) => {
-  const redirects = Promise.all([
-    digital(from),
-    s3(from),
-    showcase(from),
-    mundoHome(from),
-    mundo(from),
-  ]);
-  return redirects[1];
-};
-
-module.exports = ({ from }) => {
-  const digitalRedirect = digital(from);
-  if (digitalRedirect) return digitalRedirect;
-
-  const s3Redirect = s3(from);
-  if (s3Redirect) return s3Redirect;
-
-  const showcaseRedirect = showcase(from);
-  if (showcaseRedirect) return showcaseRedirect;
-
-  const mundoHomeRedirect = mundoHome(from);
-  if (mundoHomeRedirect) return mundoHomeRedirect;
-
-  const mundoRedirect = mundo(from);
-  if (mundoRedirect) return mundoRedirect;
 
   return null;
 };

--- a/sites/packworld/redirect-handler.js
+++ b/sites/packworld/redirect-handler.js
@@ -1,0 +1,55 @@
+const digital = async (from) => {
+  const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://digitaleditions.packworld.com/${matches[1]}` };
+  }
+  return null;
+};
+
+const s3 = async (from) => {
+  const pattern = /\/sites\/default\/files\/(.*)/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/PW/${matches[1]}` };
+  }
+  return null;
+};
+
+const showcase = async (from) => {
+  const pattern = /^\/showcasesubmit/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: 'https://showcasesubmit.packworld.com' };
+  }
+  return null;
+};
+
+const mundoHome = async (from) => {
+  const pattern = /^\/mundopmmi$/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: 'https://www.mundopmmi.com' };
+  }
+  return null;
+};
+
+const mundo = async (from) => {
+  const pattern = /^\/mundopmmi\/.*/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://www.mundopmmi.com${from}` };
+  }
+  return null;
+};
+
+module.exports = async ({ from }) => {
+  const redirects = Promise.all([
+    digital(from),
+    s3(from),
+    showcase(from),
+    mundoHome(from),
+    mundo(from),
+  ]);
+  return redirects[1];
+};

--- a/sites/packworld/redirect-handler.js
+++ b/sites/packworld/redirect-handler.js
@@ -1,4 +1,4 @@
-const digital = async (from) => {
+const digital = (from) => {
   const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -7,7 +7,7 @@ const digital = async (from) => {
   return null;
 };
 
-const s3 = async (from) => {
+const s3 = (from) => {
   const pattern = /\/sites\/default\/files\/(.*)/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -16,7 +16,7 @@ const s3 = async (from) => {
   return null;
 };
 
-const showcase = async (from) => {
+const showcase = (from) => {
   const pattern = /^\/showcasesubmit/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -25,7 +25,7 @@ const showcase = async (from) => {
   return null;
 };
 
-const mundoHome = async (from) => {
+const mundoHome = (from) => {
   const pattern = /^\/mundopmmi$/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -34,7 +34,7 @@ const mundoHome = async (from) => {
   return null;
 };
 
-const mundo = async (from) => {
+const mundo = (from) => {
   const pattern = /^\/mundopmmi\/.*/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -43,7 +43,7 @@ const mundo = async (from) => {
   return null;
 };
 
-module.exports = async ({ from }) => {
+module.exports = ({ from }) => {
   const redirects = Promise.all([
     digital(from),
     s3(from),
@@ -52,4 +52,23 @@ module.exports = async ({ from }) => {
     mundo(from),
   ]);
   return redirects[1];
+};
+
+module.exports = ({ from }) => {
+  const digitalRedirect = digital(from);
+  if (digitalRedirect) return digitalRedirect;
+
+  const s3Redirect = s3(from);
+  if (s3Redirect) return s3Redirect;
+
+  const showcaseRedirect = showcase(from);
+  if (showcaseRedirect) return showcaseRedirect;
+
+  const mundoHomeRedirect = mundoHome(from);
+  if (mundoHomeRedirect) return mundoHomeRedirect;
+
+  const mundoRedirect = mundo(from);
+  if (mundoRedirect) return mundoRedirect;
+
+  return null;
 };

--- a/sites/profoodworld/index.js
+++ b/sites/profoodworld/index.js
@@ -7,6 +7,7 @@ const coreConfig = require('./config/core');
 const document = require('./server/components/document');
 const components = require('./server/components');
 const fragments = require('./server/fragments');
+const redirectHandler = require('./redirect-handler');
 
 const { log } = console;
 
@@ -21,4 +22,5 @@ module.exports = startServer({
   version,
   onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: e => newrelic.noticeError(e),
+  redirectHandler,
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/profoodworld/redirect-handler.js
+++ b/sites/profoodworld/redirect-handler.js
@@ -1,4 +1,4 @@
-const digital = async (from) => {
+const digital = (from) => {
   const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -7,7 +7,7 @@ const digital = async (from) => {
   return null;
 };
 
-const s3 = async (from) => {
+const s3 = (from) => {
   const pattern = /\/sites\/default\/files\/(.*)/;
   const matches = pattern.exec(from);
   if (matches && matches[1]) {
@@ -16,4 +16,12 @@ const s3 = async (from) => {
   return null;
 };
 
-module.exports = async ({ from }) => Promise.all([digital(from), s3(from)]).then(l => l[0]);
+module.exports = ({ from }) => {
+  const digitalRedirect = digital(from);
+  if (digitalRedirect) return digitalRedirect;
+
+  const s3Redirect = s3(from);
+  if (s3Redirect) return s3Redirect;
+
+  return null;
+};

--- a/sites/profoodworld/redirect-handler.js
+++ b/sites/profoodworld/redirect-handler.js
@@ -1,0 +1,19 @@
+const digital = async (from) => {
+  const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://digitaleditions.profoodworld.com/${matches[1]}` };
+  }
+  return null;
+};
+
+const s3 = async (from) => {
+  const pattern = /\/sites\/default\/files\/(.*)/;
+  const matches = pattern.exec(from);
+  if (matches && matches[1]) {
+    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/PFW/${matches[1]}` };
+  }
+  return null;
+};
+
+module.exports = async ({ from }) => Promise.all([digital(from), s3(from)]).then(l => l[0]);

--- a/sites/profoodworld/redirect-handler.js
+++ b/sites/profoodworld/redirect-handler.js
@@ -1,27 +1,15 @@
-const digital = (from) => {
-  const pattern = /\/sites\/default\/files\/digital_edition\/(.*)/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
-    return { to: `https://digitaleditions.profoodworld.com/${matches[1]}` };
-  }
-  return null;
-};
-
-const s3 = (from) => {
-  const pattern = /\/sites\/default\/files\/(.*)/;
-  const matches = pattern.exec(from);
-  if (matches && matches[1]) {
-    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/PFW/${matches[1]}` };
-  }
-  return null;
-};
+const redirect = (from, pattern) => pattern.exec(from);
 
 module.exports = ({ from }) => {
-  const digitalRedirect = digital(from);
-  if (digitalRedirect) return digitalRedirect;
+  const digital = redirect(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
+  if (digital && digital[1]) {
+    return { to: `https://digitaleditions.profoodworld.com/${digital[1]}` };
+  }
 
-  const s3Redirect = s3(from);
-  if (s3Redirect) return s3Redirect;
+  const s3 = redirect(from, /\/sites\/default\/files\/(.*)/);
+  if (s3 && s3[1]) {
+    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/PFW/${s3[1]}` };
+  }
 
   return null;
 };

--- a/sites/profoodworld/redirect-handler.js
+++ b/sites/profoodworld/redirect-handler.js
@@ -1,15 +1,11 @@
-const redirect = (from, pattern) => pattern.exec(from);
+const exec = (from, pattern) => pattern.exec(from);
 
 module.exports = ({ from }) => {
-  const digital = redirect(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
-  if (digital && digital[1]) {
-    return { to: `https://digitaleditions.profoodworld.com/${digital[1]}` };
-  }
+  const digital = exec(from, /\/sites\/default\/files\/digital_edition\/(.*)/);
+  if (digital && digital[1]) return { to: `https://digitaleditions.profoodworld.com/${digital[1]}` };
 
-  const s3 = redirect(from, /\/sites\/default\/files\/(.*)/);
-  if (s3 && s3[1]) {
-    return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/PFW/${s3[1]}` };
-  }
+  const s3 = exec(from, /\/sites\/default\/files\/(.*)/);
+  if (s3 && s3[1]) return { to: `https://s3.us-east-2.amazonaws.com/pmg-production/Migrated+-+DO+NOT+USE/PFW/${s3[1]}` };
 
   return null;
 };


### PR DESCRIPTION
I put an example on each that I could find in Google that had the path that would be redirected.

Here is the [list](https://bc3-production-blobs-us-east-2.s3.us-east-2.amazonaws.com/3ea379f0-fc21-11e9-81e4-a0369f740dfa?response-content-disposition=inline%3B%20filename%3D%22pmg-brand-sites-redirects.txt%22%3B%20filename%2A%3DUTF-8%27%27pmg-brand-sites-redirects.txt&response-content-type=text%2Fplain&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJA4YU4LL6QTTS55A%2F20191101%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20191101T141340Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=2461c86dfb5d9fc1656935aa80b2f6f8b86fa45d8eb01174a6521b315b9615e5) they gave us. 