### PR TITLE
Resolve leaders header display issue on smaller screens

### DIFF
--- a/packages/common/scss/leaders.scss
+++ b/packages/common/scss/leaders.scss
@@ -11,9 +11,13 @@ $leaders-label-color: $gray-600;
     max-width: 100%;
   }
   &__callout {
+    display: none;
     align-items: center;
     font-size: 1.25rem;
     text-align: left;
+    @include media-breakpoint-up(md) {
+      display: block;
+    }
   }
   &__suppliers-callout {
     font-size: 1.5rem;


### PR DESCRIPTION
I must have forgotten to add the CSS when i removed the `d-none d-md-block` classing 🤷‍♀ 