### PR TITLE
Add company data to GAM targeting

### DIFF
--- a/packages/common/components/elements/gam-content-targeting.marko
+++ b/packages/common/components/elements/gam-content-targeting.marko
@@ -1,0 +1,16 @@
+import { getAsObject, get, getAsArray } from "@base-cms/object-path";
+
+$ const content = getAsObject(input, "obj");
+$ const { id, type } = content;
+$ const companyIds = getAsArray(content, "companies.edges").map(({ node }) => node.id);
+$ const companyId = get(content, "company.id");
+$ if (companyId) companyIds.unshift(companyId);
+$ const keyValues = {
+  cont_id: id,
+  cont_type: type,
+  ...(companyIds.length && {
+    companies: companyIds.join("|"),
+    Company: companyIds.shift(),
+  }),
+};
+<marko-web-gam-targeting key-values=keyValues />

--- a/packages/common/components/elements/marko.json
+++ b/packages/common/components/elements/marko.json
@@ -7,6 +7,10 @@
     "common-image-slider": {
       "template": "./image-slider.marko",
       "@images" : "array"
+    },
+    "common-gam-content-targeting": {
+      "template": "./gam-content-targeting.marko",
+      "@obj": "object"
     }
   }
 }

--- a/packages/common/graphql/fragments/content-page.js
+++ b/packages/common/graphql/fragments/content-page.js
@@ -55,6 +55,13 @@ fragment ContentPageFragment on Content {
       }
     }
   }
+  companies: relatedContent(input:{ includeContentTypes: Company }) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
   gating {
     surveyType
     surveyId

--- a/packages/common/graphql/fragments/content-page.js
+++ b/packages/common/graphql/fragments/content-page.js
@@ -55,7 +55,7 @@ fragment ContentPageFragment on Content {
       }
     }
   }
-  companies: relatedContent(input:{ includeContentTypes: Company }) {
+  companies: relatedContent(input: { includeContentTypes: [Company] }) {
     edges {
       node {
         id

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,6 +13,7 @@
     "@base-cms/env": "^1.0.0-beta.1",
     "@base-cms/marko-core": "^1.0.0-beta.19",
     "@base-cms/marko-web": "^1.0.0-beta.19",
+    "@base-cms/marko-web-gam": "^1.0.0-beta.4",
     "@base-cms/marko-web-gtm": "^1.0.0-beta.11",
     "@base-cms/marko-web-icons": "^1.0.0-beta.15",
     "@base-cms/marko-web-theme-default": "^1.0.0-beta.18",

--- a/sites/automationworld/server/templates/content/document.marko
+++ b/sites/automationworld/server/templates/content/document.marko
@@ -14,24 +14,14 @@ $ const displayPublishedDate = true;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
       <marko-web-gam-slots slots=adSlots />
-      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
-      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
-      $ const keyValues = {
-        cont_id: id,
-        cont_type: type,
-        ...(companies.length && {
-          companies: companies.join('|'),
-          Company: companies.shift(),
-        }),
-      };
-      <marko-web-gam-targeting key-values=keyValues />
+      <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/automationworld/server/templates/content/document.marko
+++ b/sites/automationworld/server/templates/content/document.marko
@@ -14,14 +14,24 @@ $ const displayPublishedDate = true;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      };
+      <marko-web-gam-slots slots=adSlots />
+      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
+      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
+      $ const keyValues = {
+        cont_id: id,
+        cont_type: type,
+        ...(companies.length && {
+          companies: companies.join('|'),
+          Company: companies.shift(),
+        }),
+      };
+      <marko-web-gam-targeting key-values=keyValues />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -14,15 +14,25 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-imu1": GAM.getAdUnit({ name: "imu1", aliases, size: [300, 250]}),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      };
+      <marko-web-gam-slots slots=adSlots />
+      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
+      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
+      $ const keyValues = {
+        cont_id: id,
+        cont_type: type,
+        ...(companies.length && {
+          companies: companies.join('|'),
+          Company: companies.shift(),
+        }),
+      };
+      <marko-web-gam-targeting key-values=keyValues />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -14,7 +14,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
@@ -22,17 +22,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
       <marko-web-gam-slots slots=adSlots />
-      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
-      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
-      $ const keyValues = {
-        cont_id: id,
-        cont_type: type,
-        ...(companies.length && {
-          companies: companies.join('|'),
-          Company: companies.shift(),
-        }),
-      };
-      <marko-web-gam-targeting key-values=keyValues />
+      <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/healthcarepackaging/server/templates/content/document.marko
+++ b/sites/healthcarepackaging/server/templates/content/document.marko
@@ -15,13 +15,24 @@ $ const displayPublishedDate = true;
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
     <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      };
+      <marko-web-gam-slots slots=adSlots />
+      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
+      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
+      $ const keyValues = {
+        cont_id: id,
+        cont_type: type,
+        ...(companies.length && {
+          companies: companies.join('|'),
+          Company: companies.shift(),
+        }),
+      };
+      <marko-web-gam-targeting key-values=keyValues />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/healthcarepackaging/server/templates/content/document.marko
+++ b/sites/healthcarepackaging/server/templates/content/document.marko
@@ -14,25 +14,14 @@ $ const displayPublishedDate = true;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
       <marko-web-gam-slots slots=adSlots />
-      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
-      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
-      $ const keyValues = {
-        cont_id: id,
-        cont_type: type,
-        ...(companies.length && {
-          companies: companies.join('|'),
-          Company: companies.shift(),
-        }),
-      };
-      <marko-web-gam-targeting key-values=keyValues />
+      <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -14,15 +14,25 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-imu1": GAM.getAdUnit({ name: "imu1", aliases, size: [300, 250]}),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      };
+      <marko-web-gam-slots slots=adSlots />
+      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
+      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
+      $ const keyValues = {
+        cont_id: id,
+        cont_type: type,
+        ...(companies.length && {
+          companies: companies.join('|'),
+          Company: companies.shift(),
+        }),
+      };
+      <marko-web-gam-targeting key-values=keyValues />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -14,7 +14,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-      <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
@@ -22,17 +22,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
       <marko-web-gam-slots slots=adSlots />
-      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
-      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
-      $ const keyValues = {
-        cont_id: id,
-        cont_type: type,
-        ...(companies.length && {
-          companies: companies.join('|'),
-          Company: companies.shift(),
-        }),
-      };
-      <marko-web-gam-targeting key-values=keyValues />
+      <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/oemmagazine/server/templates/content/document.marko
+++ b/sites/oemmagazine/server/templates/content/document.marko
@@ -14,24 +14,14 @@ $ const displayPublishedDate = true;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
       <marko-web-gam-slots slots=adSlots />
-      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
-      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
-      $ const keyValues = {
-        cont_id: id,
-        cont_type: type,
-        ...(companies.length && {
-          companies: companies.join('|'),
-          Company: companies.shift(),
-        }),
-      };
-      <marko-web-gam-targeting key-values=keyValues />
+      <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/oemmagazine/server/templates/content/document.marko
+++ b/sites/oemmagazine/server/templates/content/document.marko
@@ -14,14 +14,24 @@ $ const displayPublishedDate = true;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      };
+      <marko-web-gam-slots slots=adSlots />
+      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
+      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
+      $ const keyValues = {
+        cont_id: id,
+        cont_type: type,
+        ...(companies.length && {
+          companies: companies.join('|'),
+          Company: companies.shift(),
+        }),
+      };
+      <marko-web-gam-targeting key-values=keyValues />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -14,15 +14,25 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-imu1": GAM.getAdUnit({ name: "imu1", aliases, size: [300, 250]}),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      };
+      <marko-web-gam-slots slots=adSlots />
+      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
+      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
+      $ const keyValues = {
+        cont_id: id,
+        cont_type: type,
+        ...(companies.length && {
+          companies: companies.join('|'),
+          Company: companies.shift(),
+        }),
+      };
+      <marko-web-gam-targeting key-values=keyValues />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -14,7 +14,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
@@ -22,17 +22,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
       <marko-web-gam-slots slots=adSlots />
-      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
-      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
-      $ const keyValues = {
-        cont_id: id,
-        cont_type: type,
-        ...(companies.length && {
-          companies: companies.join('|'),
-          Company: companies.shift(),
-        }),
-      };
-      <marko-web-gam-targeting key-values=keyValues />
+      <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/packworld/server/templates/content/document.marko
+++ b/sites/packworld/server/templates/content/document.marko
@@ -14,24 +14,14 @@ $ const displayPublishedDate = true;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
       <marko-web-gam-slots slots=adSlots />
-      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
-      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
-      $ const keyValues = {
-        cont_id: id,
-        cont_type: type,
-        ...(companies.length && {
-          companies: companies.join('|'),
-          Company: companies.shift(),
-        }),
-      };
-      <marko-web-gam-targeting key-values=keyValues />
+      <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/packworld/server/templates/content/document.marko
+++ b/sites/packworld/server/templates/content/document.marko
@@ -14,14 +14,24 @@ $ const displayPublishedDate = true;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      };
+      <marko-web-gam-slots slots=adSlots />
+      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
+      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
+      $ const keyValues = {
+        cont_id: id,
+        cont_type: type,
+        ...(companies.length && {
+          companies: companies.join('|'),
+          Company: companies.shift(),
+        }),
+      };
+      <marko-web-gam-targeting key-values=keyValues />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -14,15 +14,25 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-imu1": GAM.getAdUnit({ name: "imu1", aliases, size: [300, 250]}),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      };
+      <marko-web-gam-slots slots=adSlots />
+      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
+      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
+      $ const keyValues = {
+        cont_id: id,
+        cont_type: type,
+        ...(companies.length && {
+          companies: companies.join('|'),
+          Company: companies.shift(),
+        }),
+      };
+      <marko-web-gam-targeting key-values=keyValues />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -14,7 +14,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
@@ -22,17 +22,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
       <marko-web-gam-slots slots=adSlots />
-      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
-      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
-      $ const keyValues = {
-        cont_id: id,
-        cont_type: type,
-        ...(companies.length && {
-          companies: companies.join('|'),
-          Company: companies.shift(),
-        }),
-      };
-      <marko-web-gam-targeting key-values=keyValues />
+      <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/profoodworld/server/templates/content/document.marko
+++ b/sites/profoodworld/server/templates/content/document.marko
@@ -14,24 +14,14 @@ $ const displayPublishedDate = true;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
       <marko-web-gam-slots slots=adSlots />
-      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
-      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
-      $ const keyValues = {
-        cont_id: id,
-        cont_type: type,
-        ...(companies.length && {
-          companies: companies.join('|'),
-          Company: companies.shift(),
-        }),
-      };
-      <marko-web-gam-targeting key-values=keyValues />
+      <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/profoodworld/server/templates/content/document.marko
+++ b/sites/profoodworld/server/templates/content/document.marko
@@ -14,14 +14,24 @@ $ const displayPublishedDate = true;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      };
+      <marko-web-gam-slots slots=adSlots />
+      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
+      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
+      $ const keyValues = {
+        cont_id: id,
+        cont_type: type,
+        ...(companies.length && {
+          companies: companies.join('|'),
+          Company: companies.shift(),
+        }),
+      };
+      <marko-web-gam-targeting key-values=keyValues />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -14,15 +14,25 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
         "gpt-ad-imu1": GAM.getAdUnit({ name: "imu1", aliases, size: [300, 250]}),
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      };
+      <marko-web-gam-slots slots=adSlots />
+      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
+      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
+      $ const keyValues = {
+        cont_id: id,
+        cont_type: type,
+        ...(companies.length && {
+          companies: companies.join('|'),
+          Company: companies.shift(),
+        }),
+      };
+      <marko-web-gam-targeting key-values=keyValues />
     </marko-web-resolve-page>
   </@head>
   <@above-container>

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -14,7 +14,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-leaderboard": GAM.getAdUnit({ name: "leaderboard", aliases }),
@@ -22,17 +22,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         "gpt-ad-skyscraper": GAM.getAdUnit({ name: "skyscraper", aliases, size: [300, 600] }),
       };
       <marko-web-gam-slots slots=adSlots />
-      $ const companies = resolved.getEdgeNodesFor('companies').map(({ id }) => id);
-      $ if (resolved.get('company.id')) companies.unshift(resolved.get('company.id'));
-      $ const keyValues = {
-        cont_id: id,
-        cont_type: type,
-        ...(companies.length && {
-          companies: companies.join('|'),
-          Company: companies.shift(),
-        }),
-      };
-      <marko-web-gam-targeting key-values=keyValues />
+      <common-gam-content-targeting obj=content />
     </marko-web-resolve-page>
   </@head>
   <@above-container>


### PR DESCRIPTION
Adds the following targeting key-values on content pages:
- `Company`: The company ID
- `companies`: A pipe concatenated list of company IDs.

In all cases, the `content.company.id` is used preferentially for the `Company`, and will fall back to related `Company` content.