### PR TITLE
Add custom podcast template

### DIFF
--- a/sites/automationworld/server/routes/content.js
+++ b/sites/automationworld/server/routes/content.js
@@ -3,6 +3,7 @@ const queryFragment = require('@base-cms-websites/package-common/graphql/fragmen
 const companyQueryFragment = require('@base-cms-websites/package-common/graphql/fragments/content-company');
 const content = require('../templates/content');
 const company = require('../templates/content/company');
+const podcast = require('../templates/content/podcast');
 const webinar = require('../templates/content/webinar');
 const document = require('../templates/content/document');
 
@@ -13,6 +14,10 @@ module.exports = (app) => {
   }));
   app.get('/*?webinar/:id(\\d{8})*', withContent({
     template: webinar,
+    queryFragment,
+  }));
+  app.get('/*?podcast/:id(\\d{8})*', withContent({
+    template: podcast,
     queryFragment,
   }));
   app.get('/*?document/:id(\\d{8})*', withContent({

--- a/sites/automationworld/server/templates/content/podcast.marko
+++ b/sites/automationworld/server/templates/content/podcast.marko
@@ -1,0 +1,41 @@
+import { getAsObject } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+
+$ const { id, type, pageNode } = data;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=content.primarySection />
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+              <common-supplier-disclaimer obj=content />
+              <default-theme-page-dates|{ blockName }|>
+                <marko-web-content-starts block-name=blockName obj=content />
+              </default-theme-page-dates>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }| class="col-lg-12 mb-3 mb-lg-0">
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+            </default-theme-page-contents>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>

--- a/sites/healthcarepackaging/server/routes/content.js
+++ b/sites/healthcarepackaging/server/routes/content.js
@@ -3,6 +3,7 @@ const queryFragment = require('@base-cms-websites/package-common/graphql/fragmen
 const companyQueryFragment = require('@base-cms-websites/package-common/graphql/fragments/content-company');
 const content = require('../templates/content');
 const company = require('../templates/content/company');
+const podcast = require('../templates/content/podcast');
 const webinar = require('../templates/content/webinar');
 const document = require('../templates/content/document');
 
@@ -13,6 +14,10 @@ module.exports = (app) => {
   }));
   app.get('/*?webinar/:id(\\d{8})*', withContent({
     template: webinar,
+    queryFragment,
+  }));
+  app.get('/*?podcast/:id(\\d{8})*', withContent({
+    template: podcast,
     queryFragment,
   }));
   app.get('/*?document/:id(\\d{8})*', withContent({

--- a/sites/healthcarepackaging/server/templates/content/podcast.marko
+++ b/sites/healthcarepackaging/server/templates/content/podcast.marko
@@ -1,0 +1,41 @@
+import { getAsObject } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+
+$ const { id, type, pageNode } = data;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=content.primarySection />
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+              <common-supplier-disclaimer obj=content />
+              <default-theme-page-dates|{ blockName }|>
+                <marko-web-content-starts block-name=blockName obj=content />
+              </default-theme-page-dates>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }| class="col-lg-12 mb-3 mb-lg-0">
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+            </default-theme-page-contents>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>

--- a/sites/oemmagazine/server/routes/content.js
+++ b/sites/oemmagazine/server/routes/content.js
@@ -3,6 +3,7 @@ const queryFragment = require('@base-cms-websites/package-common/graphql/fragmen
 const companyQueryFragment = require('@base-cms-websites/package-common/graphql/fragments/content-company');
 const content = require('../templates/content');
 const company = require('../templates/content/company');
+const podcast = require('../templates/content/podcast');
 const webinar = require('../templates/content/webinar');
 const document = require('../templates/content/document');
 
@@ -13,6 +14,10 @@ module.exports = (app) => {
   }));
   app.get('/*?webinar/:id(\\d{8})*', withContent({
     template: webinar,
+    queryFragment,
+  }));
+  app.get('/*?podcast/:id(\\d{8})*', withContent({
+    template: podcast,
     queryFragment,
   }));
   app.get('/*?document/:id(\\d{8})*', withContent({

--- a/sites/oemmagazine/server/templates/content/podcast.marko
+++ b/sites/oemmagazine/server/templates/content/podcast.marko
@@ -1,0 +1,41 @@
+import { getAsObject } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+
+$ const { id, type, pageNode } = data;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=content.primarySection />
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+              <common-supplier-disclaimer obj=content />
+              <default-theme-page-dates|{ blockName }|>
+                <marko-web-content-starts block-name=blockName obj=content />
+              </default-theme-page-dates>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }| class="col-lg-12 mb-3 mb-lg-0">
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+            </default-theme-page-contents>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>

--- a/sites/packworld/server/routes/content.js
+++ b/sites/packworld/server/routes/content.js
@@ -3,6 +3,7 @@ const queryFragment = require('@base-cms-websites/package-common/graphql/fragmen
 const companyQueryFragment = require('@base-cms-websites/package-common/graphql/fragments/content-company');
 const content = require('../templates/content');
 const company = require('../templates/content/company');
+const podcast = require('../templates/content/podcast');
 const webinar = require('../templates/content/webinar');
 const document = require('../templates/content/document');
 
@@ -13,6 +14,10 @@ module.exports = (app) => {
   }));
   app.get('/*?webinar/:id(\\d{8})*', withContent({
     template: webinar,
+    queryFragment,
+  }));
+  app.get('/*?podcast/:id(\\d{8})*', withContent({
+    template: podcast,
     queryFragment,
   }));
   app.get('/*?document/:id(\\d{8})*', withContent({

--- a/sites/packworld/server/templates/content/podcast.marko
+++ b/sites/packworld/server/templates/content/podcast.marko
@@ -1,0 +1,41 @@
+import { getAsObject } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+
+$ const { id, type, pageNode } = data;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=content.primarySection />
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+              <common-supplier-disclaimer obj=content />
+              <default-theme-page-dates|{ blockName }|>
+                <marko-web-content-starts block-name=blockName obj=content />
+              </default-theme-page-dates>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }| class="col-lg-12 mb-3 mb-lg-0">
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+            </default-theme-page-contents>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>

--- a/sites/profoodworld/server/routes/content.js
+++ b/sites/profoodworld/server/routes/content.js
@@ -3,6 +3,7 @@ const queryFragment = require('@base-cms-websites/package-common/graphql/fragmen
 const companyQueryFragment = require('@base-cms-websites/package-common/graphql/fragments/content-company');
 const content = require('../templates/content');
 const company = require('../templates/content/company');
+const podcast = require('../templates/content/podcast');
 const webinar = require('../templates/content/webinar');
 const document = require('../templates/content/document');
 
@@ -13,6 +14,10 @@ module.exports = (app) => {
   }));
   app.get('/*?webinar/:id(\\d{8})*', withContent({
     template: webinar,
+    queryFragment,
+  }));
+  app.get('/*?podcast/:id(\\d{8})*', withContent({
+    template: podcast,
     queryFragment,
   }));
   app.get('/*?document/:id(\\d{8})*', withContent({

--- a/sites/profoodworld/server/templates/content/podcast.marko
+++ b/sites/profoodworld/server/templates/content/podcast.marko
@@ -1,0 +1,41 @@
+import { getAsObject } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+
+$ const { id, type, pageNode } = data;
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+  </@head>
+  <@page>
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=content.primarySection />
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+              <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
+              <common-supplier-disclaimer obj=content />
+              <default-theme-page-dates|{ blockName }|>
+                <marko-web-content-starts block-name=blockName obj=content />
+              </default-theme-page-dates>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <default-theme-page-contents|{ blockName }| class="col-lg-12 mb-3 mb-lg-0">
+              <default-theme-content-contact-details obj=content />
+              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-content-sidebars block-name=blockName obj=content />
+            </default-theme-page-contents>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-content-page-layout>


### PR DESCRIPTION
Remove ads, primary image, load more like on Webinar template.
![screencapture-0-0-0-0-9710-products-control-podcast-15611735-are-servo-motor-and-drive-combinations-from-one-vendor-better-2019-11-08-08_33_26](https://user-images.githubusercontent.com/1778222/68484281-95860580-0202-11ea-8e4f-51911cb18ff7.jpg)
