### PR TITLE
Track events from company pages

### DIFF
--- a/packages/common/browser/index.js
+++ b/packages/common/browser/index.js
@@ -3,10 +3,18 @@ import Leaders from '@base-cms/marko-web-leaders/browser';
 const ImageSlider = () => import(/* webpackChunkName: "common-image-slider" */ './image-slider.vue');
 const ContactUsForm = () => import(/* webpackChunkName: "common-contact-us" */ './contact-us-form.vue');
 const CommonGTMTrackLeaders = () => import(/* webpackChunkName: "common-gtm-track-leaders" */ './gtm-track-leaders.vue');
+const CommonLeadersCompanyWebsiteLink = () => import(/* webpackChunkName: "common-leaders-company-website-link" */ './leaders-company-website-link.vue');
+const CommonLeadersCompanySocialLink = () => import(/* webpackChunkName: "common-leaders-company-social-link" */ './leaders-company-social-link.vue');
 
 export default (Browser) => {
   const { EventBus } = Browser;
   Browser.register('CommonGTMTrackLeaders', CommonGTMTrackLeaders, { provide: { EventBus } });
+  Browser.register('CommonLeadersCompanyWebsiteLink', CommonLeadersCompanyWebsiteLink, {
+    on: { action: (...args) => EventBus.$emit('leaders-action', ...args) },
+  });
+  Browser.register('CommonLeadersCompanySocialLink', CommonLeadersCompanySocialLink, {
+    on: { action: (...args) => EventBus.$emit('leaders-action', ...args) },
+  });
   Leaders(Browser);
 
   // @todo this should be removed once contact us is moved to core.

--- a/packages/common/browser/leaders-company-social-link.vue
+++ b/packages/common/browser/leaders-company-social-link.vue
@@ -1,10 +1,10 @@
 <template>
   <a
     :href="href"
-    :target="target"
+    target="_blank"
     class="social-icon-link"
     :title="title"
-    :rel="rel"
+    rel="nofollow"
     @click="emitAction"
   >
     <component :is="icon" :modifiers="modifiers" />
@@ -43,8 +43,6 @@ export default {
     },
   },
   data: () => ({
-    target: '_blank',
-    rel: 'nofollow',
     modifiers: ['dark', 'lg'],
   }),
   computed: {

--- a/packages/common/browser/leaders-company-social-link.vue
+++ b/packages/common/browser/leaders-company-social-link.vue
@@ -1,0 +1,73 @@
+<template>
+  <a
+    :href="href"
+    :target="target"
+    class="social-icon-link"
+    :title="title"
+    :rel="rel"
+    @click="emitAction"
+  >
+    <component :is="icon" :modifiers="modifiers" />
+  </a>
+</template>
+
+<script>
+import Youtube from '@base-cms/marko-web-icons/browser/youtube.vue';
+import Linkedin from '@base-cms/marko-web-icons/browser/linkedin.vue';
+import Facebook from '@base-cms/marko-web-icons/browser/facebook.vue';
+import Twitter from '@base-cms/marko-web-icons/browser/twitter.vue';
+
+export default {
+  components: {
+    'icon-youtube': Youtube,
+    'icon-linkedin': Linkedin,
+    'icon-facebook': Facebook,
+    'icon-twitter': Twitter,
+  },
+  props: {
+    companyId: {
+      type: Number,
+      required: true,
+    },
+    companyName: {
+      type: String,
+      required: true,
+    },
+    href: {
+      type: String,
+      required: true,
+    },
+    provider: {
+      type: String,
+      required: true,
+    },
+  },
+  data: () => ({
+    target: '_blank',
+    rel: 'nofollow',
+    modifiers: ['dark', 'lg'],
+  }),
+  computed: {
+    icon() {
+      return `icon-${this.provider}`;
+    },
+    title() {
+      return `Visit us on ${this.provider.charAt(0).toUpperCase()}${this.provider.slice(1)}`;
+    },
+  },
+  methods: {
+    emitAction() {
+      const payload = {
+        category: 'Leaders Company Profile',
+        type: 'click',
+        label: `Company Social - ${this.provider}`,
+      };
+      const data = {
+        companyId: this.companyId,
+        companyName: this.companyName,
+      };
+      this.$emit('action', payload, data);
+    },
+  },
+};
+</script>

--- a/packages/common/browser/leaders-company-social-link.vue
+++ b/packages/common/browser/leaders-company-social-link.vue
@@ -12,17 +12,17 @@
 </template>
 
 <script>
-import Youtube from '@base-cms/marko-web-icons/browser/youtube.vue';
-import Linkedin from '@base-cms/marko-web-icons/browser/linkedin.vue';
-import Facebook from '@base-cms/marko-web-icons/browser/facebook.vue';
-import Twitter from '@base-cms/marko-web-icons/browser/twitter.vue';
+import IconYoutube from '@base-cms/marko-web-icons/browser/youtube.vue';
+import IconLinkedin from '@base-cms/marko-web-icons/browser/linkedin.vue';
+import IconFacebook from '@base-cms/marko-web-icons/browser/facebook.vue';
+import IconTwitter from '@base-cms/marko-web-icons/browser/twitter.vue';
 
 export default {
   components: {
-    'icon-youtube': Youtube,
-    'icon-linkedin': Linkedin,
-    'icon-facebook': Facebook,
-    'icon-twitter': Twitter,
+    IconYoutube,
+    IconLinkedin,
+    IconFacebook,
+    IconTwitter,
   },
   props: {
     companyId: {

--- a/packages/common/browser/leaders-company-website-link.vue
+++ b/packages/common/browser/leaders-company-website-link.vue
@@ -1,0 +1,46 @@
+<template>
+  <a
+    :href="href"
+    target="_blank"
+    class="btn btn-sm btn-primary btn-block"
+    title="Visit Site"
+    rel="nofollow"
+    @click="emitAction"
+  >
+    Visit Site
+  </a>
+</template>
+
+<script>
+
+export default {
+  props: {
+    companyId: {
+      type: Number,
+      required: true,
+    },
+    companyName: {
+      type: String,
+      required: true,
+    },
+    href: {
+      type: String,
+      required: true,
+    },
+  },
+  methods: {
+    emitAction() {
+      const payload = {
+        category: 'Leaders Company Profile',
+        type: 'click',
+        label: 'Company Website',
+      };
+      const data = {
+        companyId: this.companyId,
+        companyName: this.companyName,
+      };
+      this.$emit('action', payload, data);
+    },
+  },
+};
+</script>

--- a/packages/common/components/leaders/company-social-link.marko
+++ b/packages/common/components/leaders/company-social-link.marko
@@ -1,0 +1,12 @@
+import { get, getAsObject } from "@base-cms/object-path";
+
+$ const { id, name } = getAsObject(input, "company");
+$ const { url: href, label, provider } = getAsObject(input, "item");
+$ const props = {
+  companyId: id,
+  companyName: name,
+  href,
+  provider,
+};
+
+<marko-web-browser-component name="CommonLeadersCompanySocialLink" props=props />

--- a/packages/common/components/leaders/company-website-link.marko
+++ b/packages/common/components/leaders/company-website-link.marko
@@ -1,0 +1,7 @@
+import { get, getAsObject } from "@base-cms/object-path";
+
+$ const { id, name } = getAsObject(input, "company");
+$ const href = get(input, "company.website");
+$ const props = { companyId: id, companyName: name, href };
+
+<marko-web-browser-component name="CommonLeadersCompanyWebsiteLink" props=props />

--- a/packages/common/components/leaders/marko.json
+++ b/packages/common/components/leaders/marko.json
@@ -15,6 +15,12 @@
     },
     "common-leaders-gtm-tracker": {
       "template": "./gtm-tracker.marko"
+    },
+    "common-leaders-company-website-link": {
+      "template": "./company-website-link.marko"
+    },
+    "common-leaders-company-social-link": {
+      "template": "./company-social-link.marko"
     }
   }
 }

--- a/packages/common/components/leaders/marko.json
+++ b/packages/common/components/leaders/marko.json
@@ -17,10 +17,13 @@
       "template": "./gtm-tracker.marko"
     },
     "common-leaders-company-website-link": {
-      "template": "./company-website-link.marko"
+      "template": "./company-website-link.marko",
+      "@company": "object"
     },
     "common-leaders-company-social-link": {
-      "template": "./company-social-link.marko"
+      "template": "./company-social-link.marko",
+      "@company": "object",
+      "@item": "object"
     }
   }
 }

--- a/sites/automationworld/server/templates/content/company.marko
+++ b/sites/automationworld/server/templates/content/company.marko
@@ -29,17 +29,10 @@ $ const { id, type, pageNode } = data;
             </div>
             <div class="col-md-3 col-lg-2 col-sm-12 justify-content-center d-flex flex-column px-3 py-3">
               <div class="ldp__social">
-                <marko-web-content-website obj=content link={ class: "btn btn-sm btn-primary btn-block" }>
-                  Visit Site
-                </marko-web-content-website>
+                <common-leaders-company-website-link company=content />
                 <div class="mt-2 d-flex justify-content-around">
                   <for|item| of=content.socialLinks>
-                    <default-theme-social-icon-link
-                      label=item.label
-                      provider=item.provider
-                      href=item.url
-                      modifiers=["dark", "lg"]
-                    />
+                    <common-leaders-company-social-link company=content item=item />
                   </for>
                 </div>
               </div>

--- a/sites/healthcarepackaging/server/templates/content/company.marko
+++ b/sites/healthcarepackaging/server/templates/content/company.marko
@@ -29,17 +29,10 @@ $ const { id, type, pageNode } = data;
             </div>
             <div class="col-md-3 col-lg-2 col-sm-12 justify-content-center d-flex flex-column px-3 py-3">
               <div class="ldp__social">
-                <marko-web-content-website obj=content link={ class: "btn btn-sm btn-primary btn-block" }>
-                  Visit Site
-                </marko-web-content-website>
+                <common-leaders-company-website-link company=content />
                 <div class="mt-2 d-flex justify-content-around">
                   <for|item| of=content.socialLinks>
-                    <default-theme-social-icon-link
-                      label=item.label
-                      provider=item.provider
-                      href=item.url
-                      modifiers=["dark", "lg"]
-                    />
+                    <common-leaders-company-social-link company=content item=item />
                   </for>
                 </div>
               </div>

--- a/sites/oemmagazine/server/templates/content/company.marko
+++ b/sites/oemmagazine/server/templates/content/company.marko
@@ -29,17 +29,10 @@ $ const { id, type, pageNode } = data;
             </div>
             <div class="col-md-3 col-lg-2 col-sm-12 justify-content-center d-flex flex-column px-3 py-3">
               <div class="ldp__social">
-                <marko-web-content-website obj=content link={ class: "btn btn-sm btn-primary btn-block" }>
-                  Visit Site
-                </marko-web-content-website>
+                <common-leaders-company-website-link company=content />
                 <div class="mt-2 d-flex justify-content-around">
                   <for|item| of=content.socialLinks>
-                    <default-theme-social-icon-link
-                      label=item.label
-                      provider=item.provider
-                      href=item.url
-                      modifiers=["dark", "lg"]
-                    />
+                    <common-leaders-company-social-link company=content item=item />
                   </for>
                 </div>
               </div>

--- a/sites/packworld/server/templates/content/company.marko
+++ b/sites/packworld/server/templates/content/company.marko
@@ -29,17 +29,10 @@ $ const { id, type, pageNode } = data;
             </div>
             <div class="col-md-3 col-lg-2 col-sm-12 justify-content-center d-flex flex-column px-3 py-3">
               <div class="ldp__social">
-                <marko-web-content-website obj=content link={ class: "btn btn-sm btn-primary btn-block" }>
-                  Visit Site
-                </marko-web-content-website>
+                <common-leaders-company-website-link company=content />
                 <div class="mt-2 d-flex justify-content-around">
                   <for|item| of=content.socialLinks>
-                    <default-theme-social-icon-link
-                      label=item.label
-                      provider=item.provider
-                      href=item.url
-                      modifiers=["dark", "lg"]
-                    />
+                    <common-leaders-company-social-link company=content item=item />
                   </for>
                 </div>
               </div>

--- a/sites/profoodworld/server/templates/content/company.marko
+++ b/sites/profoodworld/server/templates/content/company.marko
@@ -29,17 +29,10 @@ $ const { id, type, pageNode } = data;
             </div>
             <div class="col-md-3 col-lg-2 col-sm-12 justify-content-center d-flex flex-column px-3 py-3">
               <div class="ldp__social">
-                <marko-web-content-website obj=content link={ class: "btn btn-sm btn-primary btn-block" }>
-                  Visit Site
-                </marko-web-content-website>
+                <common-leaders-company-website-link company=content />
                 <div class="mt-2 d-flex justify-content-around">
                   <for|item| of=content.socialLinks>
-                    <default-theme-social-icon-link
-                      label=item.label
-                      provider=item.provider
-                      href=item.url
-                      modifiers=["dark", "lg"]
-                    />
+                    <common-leaders-company-social-link company=content item=item />
                   </for>
                 </div>
               </div>


### PR DESCRIPTION
Replaces website and social links on company profile pages with Vue components that send leadership events to GTM.