### PR TITLE
Don’t include carousel for post-launch content

### DIFF
--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && content.published < 1572411600000)>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/automationworld/server/templates/content/index.marko
+++ b/sites/automationworld/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && content.published < 1572411600000)>
+                <if(images.length > 1 && content.published < new Date(2019, 9, 30))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && content.published < 1572411600000)>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/healthcarepackaging/server/templates/content/index.marko
+++ b/sites/healthcarepackaging/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && content.published < 1572411600000)>
+                <if(images.length > 1 && content.published < new Date(2019, 9, 30))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && content.published < 1572411600000)>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/oemmagazine/server/templates/content/index.marko
+++ b/sites/oemmagazine/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && content.published < 1572411600000)>
+                <if(images.length > 1 && content.published < new Date(2019, 9, 30))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && content.published < 1572411600000)>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/packworld/server/templates/content/index.marko
+++ b/sites/packworld/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && content.published < 1572411600000)>
+                <if(images.length > 1 && content.published < new Date(2019, 9, 30))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && content.published < 1572411600000)>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/profoodworld/server/templates/content/index.marko
+++ b/sites/profoodworld/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && content.published < 1572411600000)>
+                <if(images.length > 1 && content.published < new Date(2019, 9, 30))>
                   <common-image-slider images=images />
                 </if>
                 <else>


### PR DESCRIPTION
Drop the carousel in favor of primary image only for all post-launch content.

**Before:**
![Screen Shot 2019-11-15 at 2 03 05 PM](https://user-images.githubusercontent.com/2855198/68972194-d789eb00-07b0-11ea-841e-5c867b125904.png)


**After:**
![Screen Shot 2019-11-15 at 2 03 00 PM](https://user-images.githubusercontent.com/2855198/68972203-de186280-07b0-11ea-8615-61ebb125f2f4.png)
