### PR TITLE
Ensure content has an active status when displaying carousel

### DIFF
--- a/packages/common/graphql/fragments/content-page.js
+++ b/packages/common/graphql/fragments/content-page.js
@@ -7,6 +7,7 @@ fragment ContentPageFragment on Content {
   labels
   teaser(input: { useFallback: false, maxLength: null })
   body
+  status
   published
   company {
     id

--- a/sites/automationworld.com/server/templates/content/index.marko
+++ b/sites/automationworld.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && content.published < new Date(2019, 9, 30))>
+                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/healthcarepackaging.com/server/templates/content/index.marko
+++ b/sites/healthcarepackaging.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && content.published < new Date(2019, 9, 30))>
+                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/oemmagazine.org/server/templates/content/index.marko
+++ b/sites/oemmagazine.org/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && content.published < new Date(2019, 9, 30))>
+                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/packworld.com/server/templates/content/index.marko
+++ b/sites/packworld.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && content.published < new Date(2019, 9, 30))>
+                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/profoodworld.com/server/templates/content/index.marko
+++ b/sites/profoodworld.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && content.published < new Date(2019, 9, 30))>
+                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
                   <common-image-slider images=images />
                 </if>
                 <else>


### PR DESCRIPTION
Currently, if the published date is null, the carousel will still display, so it’s causing confusion when the editors check the preview mode of the content and see the carousel.

This way, the content has to be published for the carousel to display.  (Draft & Deleted won’t display it in preview)