### PR TITLE
Sponsored search

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ x-env-defaults: &env
   # @todo the sendgrid values should be removed once the @base-cms/mailer service is created.
   SENDGRID_API_KEY: ${SENDGRID_API_KEY-(unset)}
   SENDGRID_DEV_TO: developer@endeavorb2b.com
+  SPONSORED_SEARCH_ENABLED: ${SPONSORED_SEARCH_ENABLED}
   YARN_CACHE_FOLDER: /.yarn-cache
 
 x-env-caprica: &env-caprica-staging

--- a/packages/common/components/blocks/marko.json
+++ b/packages/common/components/blocks/marko.json
@@ -17,6 +17,13 @@
         "type": "number",
         "required": true
       }
+    },
+    "common-sponsored-search-nav": {
+      "template": "./sponsored-search-nav.marko",
+      "@image": "string"
+    },
+    "common-sponsored-search-block": {
+      "template": "./sponsored-search-block.marko"
     }
   }
 }

--- a/packages/common/components/blocks/sponsored-search-block.marko
+++ b/packages/common/components/blocks/sponsored-search-block.marko
@@ -1,0 +1,12 @@
+$ const { site } = out.global;
+$ const block = "sponsored-search-block";
+$ const image = site.get('sponsoredSearch.blockImage');
+$ const src = `${image}?h=50`;
+$ const srcset = `${image}?h=100 2x`;
+
+<if(site.get('sponsoredSearch.enabled'))>
+  <div class=block>
+    <span class=`${block}__text`>Sponsored by</span>
+    <img class=`${block}__logo` src=src srcset=srcset />
+  </div>
+</if>

--- a/packages/common/components/blocks/sponsored-search-nav.marko
+++ b/packages/common/components/blocks/sponsored-search-nav.marko
@@ -1,0 +1,9 @@
+$ const block = "sponsored-search-nav";
+$ const { image } = input;
+$ const src = `${image}?h=30`;
+$ const srcset = `${image}?h=60 2x`;
+
+<div class=block>
+  <marko-web-icon class=`${block}__icon` name="search" attrs={ title: "Search" } />
+  <img class=`${block}__logo` src=src srcset=srcset />
+</div>

--- a/packages/common/scss/common.scss
+++ b/packages/common/scss/common.scss
@@ -29,6 +29,7 @@ $theme-site-header-breakpoints: (
 @import "./contact-us-form"; // @todo this should be remove once contact us is in core
 @import "./company-page";
 @import "./leaders-index-page";
+@import "./sponsored-search";
 
 .leaders {
   @include border-radius($theme-card-border-radius);

--- a/packages/common/scss/sponsored-search.scss
+++ b/packages/common/scss/sponsored-search.scss
@@ -1,0 +1,17 @@
+.sponsored-search-nav {
+  &__logo {
+    margin-left: map-get($spacers, 1);
+  }
+}
+
+.sponsored-search-block {
+  float: right;
+  font-size: 1rem;
+  &__logo {
+    margin-left: map-get($spacers, 2);
+  }
+  @include media-breakpoint-down("md") {
+    float: none;
+    text-align: center;
+  }
+}

--- a/sites/automationworld.com/config/site.js
+++ b/sites/automationworld.com/config/site.js
@@ -1,5 +1,17 @@
+const sponsoredSearchNav = require('../../../packages/common/components/blocks/sponsored-search-nav');
 const navigation = require('./navigation');
 const leaders = require('./leaders');
+
+const sponsoredSearch = {
+  enabled: process.env.SPONSORED_SEARCH_ENABLED || false,
+  navImage: 'https://img.automationworld.com/files/base/pmmi/all/PROFINET-white.png',
+  blockImage: 'https://img.automationworld.com/files/base/pmmi/all/PROFINET-rgb.png',
+};
+
+if (sponsoredSearch.enabled) {
+  const label = sponsoredSearchNav.renderToString({ image: sponsoredSearch.navImage });
+  navigation.tertiary.items[0] = { href: '/search', label };
+}
 
 module.exports = {
   navigation,
@@ -35,4 +47,5 @@ module.exports = {
   magazines: {
     description: '',
   },
+  sponsoredSearch,
 };

--- a/sites/automationworld.com/server/templates/search.marko
+++ b/sites/automationworld.com/server/templates/search.marko
@@ -22,7 +22,10 @@ $ const description = `Search ${config.siteName()}`;
             <default-theme-breadcrumbs-with-home>
               <@item>${title}</@item>
             </default-theme-breadcrumbs-with-home>
-            <h1 class="page-wrapper__title">${description}</h1>
+            <h1 class="page-wrapper__title">
+              ${description}
+              <common-sponsored-search-block />
+            </h1>
           </div>
         </div>
       </@section>


### PR DESCRIPTION
Implement sponsored search feature

This feature can be enabled via the environment variable `SPONSORED_SEARCH_ENABLED`. This feature will be reviewed by the client once tagged to the staging environment. Further changes are likely necessary, hence the env option (combined with a future launch date of Feb 1).

Design Doc
![sponsored-search](https://user-images.githubusercontent.com/1778222/71920996-97f6d400-314d-11ea-8395-88d189ac8e8f.png)

Screenshot
![screencapture-0-0-0-0-9710-search-2020-01-07-12_56_59](https://user-images.githubusercontent.com/1778222/71921013-9e854b80-314d-11ea-9b3f-03ff746bf7b5.jpg)
