### PR TITLE
Add Downloads to navigation & update leaders layout

### DIFF
--- a/sites/automationworld.com/server/templates/published-content/documents.marko
+++ b/sites/automationworld.com/server/templates/published-content/documents.marko
@@ -15,7 +15,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <!-- <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] /> -->
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">
@@ -32,17 +32,17 @@ $ const description = defaultDescription(title, config);
 
     <marko-web-query|{ nodes }|
       name="all-published-content"
-      params={ contentTypes: ["Document"], limit: 18, queryFragment }
+      params={ contentTypes: ["Document"], limit: 12, queryFragment }
     >
-      <website-content-list-flow nodes=nodes />
+    <website-content-card-deck-flow nodes=nodes />
     </marko-web-query>
   </@page>
   <@below-page>
     <marko-web-load-more
-      component-name="content-list-flow"
+      component-name="content-card-deck-flow"
       fragment-name="content-list"
       query-name="all-published-content"
-      query-params={ contentTypes: ["Document"], limit: 18, skip: 18 }
+      query-params={ contentTypes: ["Document"], limit: 12, skip: 12 }
       page-input={ for: "published-content" }
     />
   </@below-page>

--- a/sites/automationworld.com/server/templates/website-section/leaders.marko
+++ b/sites/automationworld.com/server/templates/website-section/leaders.marko
@@ -38,13 +38,13 @@ $ const { id, alias, name, pageNode } = data;
               </h1>
               <div class="leaders-index-page__description">
                 <p>Welcome to <em>${config.siteName()}'s</em> ${site.get("leaders.title")} program.</p>
-                <p>Vote for your 2020 Honorees <marko-web-link href="https://bit.ly/2Lqg66e" target="_blank">here</marko-web-link>.</p>
+                <p>Vote for your 2021 Honorees <marko-web-link href="https://pmmi.iad1.qualtrics.com/jfe/form/SV_07nsCA1WvdghaK1" target="_blank">here</marko-web-link>.</p>
               </div>
             </div>
           </div>
           <div class="leaders-index-page__body">
             <p>Recognize innovation, leadership and excellence among suppliers of automation software, technology and products.</p>
-            <p>Read the Automation World feature article to see all the <a href="/13319442">2019 First Team Honorees</a>.</p>
+            <p>Read the Automation World feature article to see all the <a href="/21112298">2020 First Team Honorees</a>.</p>
             <p><em>Thanks for your participation, which promotes excellence within the automation community!</em></p>
           </div>
         </div>

--- a/sites/healthcarepackaging.com/server/templates/published-content/documents.marko
+++ b/sites/healthcarepackaging.com/server/templates/published-content/documents.marko
@@ -15,7 +15,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <!-- <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] /> -->
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">
@@ -32,17 +32,17 @@ $ const description = defaultDescription(title, config);
 
     <marko-web-query|{ nodes }|
       name="all-published-content"
-      params={ contentTypes: ["Document"], limit: 18, queryFragment }
+      params={ contentTypes: ["Document"], limit: 12, queryFragment }
     >
-      <website-content-list-flow nodes=nodes />
+    <website-content-card-deck-flow nodes=nodes />
     </marko-web-query>
   </@page>
   <@below-page>
     <marko-web-load-more
-      component-name="content-list-flow"
+      component-name="content-card-deck-flow"
       fragment-name="content-list"
       query-name="all-published-content"
-      query-params={ contentTypes: ["Document"], limit: 18, skip: 18 }
+      query-params={ contentTypes: ["Document"], limit: 12, skip: 12 }
       page-input={ for: "published-content" }
     />
   </@below-page>

--- a/sites/oemmagazine.org/config/navigation.js
+++ b/sites/oemmagazine.org/config/navigation.js
@@ -6,7 +6,7 @@ module.exports = {
       { href: '/products', label: 'Products' },
       { href: '/oem-issues', label: 'OEM Issues' },
       { href: '/page/oem-event-calendar', label: 'Events' },
-      // { href: '/downloads', label: 'Downloads' },
+      { href: '/downloads', label: 'Downloads' },
     ],
   },
   tertiary: {
@@ -38,7 +38,7 @@ module.exports = {
       items: [
         // { href: '/magazine', label: 'Magazine' },
         { href: '/page/oem-event-calendar', label: 'Events' },
-        // { href: '/downloads', label: 'Downloads' },
+        { href: '/downloads', label: 'Downloads' },
         { href: '/leaders', label: 'Tech Trendsetters' },
         { href: '/videos', label: 'Videos' },
       ],

--- a/sites/oemmagazine.org/server/templates/published-content/documents.marko
+++ b/sites/oemmagazine.org/server/templates/published-content/documents.marko
@@ -15,7 +15,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <!-- <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] /> -->
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">
@@ -32,17 +32,17 @@ $ const description = defaultDescription(title, config);
 
     <marko-web-query|{ nodes }|
       name="all-published-content"
-      params={ contentTypes: ["Document"], limit: 18, queryFragment }
+      params={ contentTypes: ["Document"], limit: 12, queryFragment }
     >
-      <website-content-list-flow nodes=nodes />
+    <website-content-card-deck-flow nodes=nodes />
     </marko-web-query>
   </@page>
   <@below-page>
     <marko-web-load-more
-      component-name="content-list-flow"
+      component-name="content-card-deck-flow"
       fragment-name="content-list"
       query-name="all-published-content"
-      query-params={ contentTypes: ["Document"], limit: 18, skip: 18 }
+      query-params={ contentTypes: ["Document"], limit: 12, skip: 12 }
       page-input={ for: "published-content" }
     />
   </@below-page>

--- a/sites/packworld.com/config/navigation.js
+++ b/sites/packworld.com/config/navigation.js
@@ -6,7 +6,7 @@ module.exports = {
       { href: '/design', label: 'Design' },
       { href: '/issues', label: 'Issues' },
       { href: '/page/pw-event-calendar', label: 'Events' },
-      // { href: '/downloads', label: 'Downloads' },
+      { href: '/downloads', label: 'Downloads' },
     ],
   },
   tertiary: {
@@ -39,7 +39,7 @@ module.exports = {
         // { href: '/magazine', label: 'Magazine' },
         { href: '/page/contract-packaging-magazine', label: 'Contract Packaging' },
         { href: '/page/pw-event-calendar', label: 'Events' },
-        // { href: '/downloads', label: 'Downloads' },
+        { href: '/downloads', label: 'Downloads' },
         { href: '/leaders', label: 'Leaders in Packaging' },
         { href: '/videos', label: 'Videos' },
         { href: '/page/packaging-associations', label: 'Packaging Associations' },

--- a/sites/packworld.com/server/templates/published-content/documents.marko
+++ b/sites/packworld.com/server/templates/published-content/documents.marko
@@ -15,7 +15,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <!-- <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] /> -->
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">
@@ -32,17 +32,17 @@ $ const description = defaultDescription(title, config);
 
     <marko-web-query|{ nodes }|
       name="all-published-content"
-      params={ contentTypes: ["Document"], limit: 18, queryFragment }
+      params={ contentTypes: ["Document"], limit: 12, queryFragment }
     >
-      <website-content-list-flow nodes=nodes />
+    <website-content-card-deck-flow nodes=nodes />
     </marko-web-query>
   </@page>
   <@below-page>
     <marko-web-load-more
-      component-name="content-list-flow"
+      component-name="content-card-deck-flow"
       fragment-name="content-list"
       query-name="all-published-content"
-      query-params={ contentTypes: ["Document"], limit: 18, skip: 18 }
+      query-params={ contentTypes: ["Document"], limit: 12, skip: 12 }
       page-input={ for: "published-content" }
     />
   </@below-page>

--- a/sites/profoodworld.com/config/navigation.js
+++ b/sites/profoodworld.com/config/navigation.js
@@ -6,7 +6,7 @@ module.exports = {
       { href: '/automation', label: 'Automation' },
       { href: '/food-safety', label: 'Food Safety' },
       { href: '/events', label: 'Events' },
-      // { href: '/downloads', label: 'Downloads' },
+      { href: '/downloads', label: 'Downloads' },
     ],
   },
   tertiary: {
@@ -38,7 +38,7 @@ module.exports = {
       items: [
         // { href: '/magazine', label: 'Magazine' },
         { href: '/events', label: 'Events' },
-        // { href: '/downloads', label: 'Downloads' },
+        { href: '/downloads', label: 'Downloads' },
         { href: '/leaders', label: 'Leaders in Processing' },
         // { href: '/global-250', label: 'Global 250' },
         // { href: '/awards', label: 'Awards' },

--- a/sites/profoodworld.com/server/templates/published-content/documents.marko
+++ b/sites/profoodworld.com/server/templates/published-content/documents.marko
@@ -15,7 +15,7 @@ $ const description = defaultDescription(title, config);
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <!-- <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] /> -->
     <marko-web-page-wrapper class="mb-block">
       <@section>
         <div class="row">
@@ -32,17 +32,17 @@ $ const description = defaultDescription(title, config);
 
     <marko-web-query|{ nodes }|
       name="all-published-content"
-      params={ contentTypes: ["Document"], limit: 18, queryFragment }
+      params={ contentTypes: ["Document"], limit: 12, queryFragment }
     >
-      <website-content-list-flow nodes=nodes />
+    <website-content-card-deck-flow nodes=nodes />
     </marko-web-query>
   </@page>
   <@below-page>
     <marko-web-load-more
-      component-name="content-list-flow"
+      component-name="content-card-deck-flow"
       fragment-name="content-list"
       query-name="all-published-content"
-      query-params={ contentTypes: ["Document"], limit: 18, skip: 18 }
+      query-params={ contentTypes: ["Document"], limit: 12, skip: 12 }
       page-input={ for: "published-content" }
     />
   </@below-page>


### PR DESCRIPTION
Modified the layout of “Downloads” (Documents) to a card-style from list-style, added it to the nav for all PMMI sites (uncommented existing nav items)
Per Zanzy in BCMS-302

![Screen Shot 2020-01-28 at 3 20 36 PM](https://user-images.githubusercontent.com/12496550/73308490-05929f00-41e6-11ea-8338-535770c29838.png)


![Screen Shot 2020-01-28 at 3 47 49 PM](https://user-images.githubusercontent.com/12496550/73308497-075c6280-41e6-11ea-9a3b-6b003b6977a6.png)


Also updated Leaders landing page URL
![Screen Shot 2020-01-28 at 3 51 37 PM](https://user-images.githubusercontent.com/12496550/73308531-16431500-41e6-11ea-939d-066159cc637a.png)
