### PR TITLE
Troubleshoot GTM+Leadworks integration

### DIFF
--- a/packages/common/components/blocks/leadership-company-videos.marko
+++ b/packages/common/components/blocks/leadership-company-videos.marko
@@ -10,19 +10,23 @@ $ const { contentId } = input;
   <if(nodes.length)>
     <for|company| of=nodes>
       <if(company.isLeader)>
+        $ const linkAttrs = {
+          'data-company-id': company.id,
+          'data-company-name': company.name,
+        };
         $ const videos = getAsArray(company, "videos.edges").map(({ node }) => node);
         <if(videos.length)>
           <marko-web-node-list class="mt-block" collapsible=false>
             <@header modifiers=["leadership-company-videos"]>
               <span>Videos from ${company.name}</span>
-              <marko-web-link target="_blank" href=get(company, "youtube.url")>
+              <marko-web-link target="_blank" href=get(company, "youtube.url") attrs=linkAttrs>
                 View all videos
               </marko-web-link>
             </@header>
             <@body>
               <default-theme-card-deck-flow cols=3 nodes=videos>
                 <@slot|{ node, index }|>
-                  <common-youtube-card-node node=node />
+                  <common-youtube-card-node node=node link-attrs=linkAttrs />
                 </@slot>
               </default-theme-card-deck-flow>
             </@body>

--- a/packages/common/components/nodes/marko.json
+++ b/packages/common/components/nodes/marko.json
@@ -2,7 +2,8 @@
   "tags": {
     "common-youtube-card-node": {
       "template": "./youtube-card.marko",
-      "@node": "object"
+      "@node": "object",
+      "@link-attrs": "object"
     },
     "common-author-card-node": {
       "template": "./author-card.marko",

--- a/packages/common/components/nodes/youtube-card.marko
+++ b/packages/common/components/nodes/youtube-card.marko
@@ -18,7 +18,8 @@ $ const { linkAttrs } = input;
     alt=video.title
     fluid=true
     ar="4:3"
-    link={ href: video.url, target: "_blank", attrs: linkAttrs }
+    link={ href: video.url, target: "_blank" }
+    attrs=linkAttrs
   />
   <@body>
     <@title tag="h5" modifiers=input.titleModifiers>

--- a/sites/automationworld.com/server/templates/content/company.marko
+++ b/sites/automationworld.com/server/templates/content/company.marko
@@ -121,7 +121,10 @@ $ const { id, type, pageNode } = data;
             <@nodes|{ nodes }| nodes=videos>
               <for|node| of=nodes>
                 <div class="node-list__node">
-                  <common-youtube-card-node node=node />
+                  <common-youtube-card-node node=node link-attrs={
+                    'data-company-id': content.id,
+                    'data-company-name': content.name,
+                  } />
                 </div>
               </for>
             </@nodes>

--- a/sites/healthcarepackaging.com/server/templates/content/company.marko
+++ b/sites/healthcarepackaging.com/server/templates/content/company.marko
@@ -121,7 +121,10 @@ $ const { id, type, pageNode } = data;
             <@nodes|{ nodes }| nodes=videos>
               <for|node| of=nodes>
                 <div class="node-list__node">
-                  <common-youtube-card-node node=node />
+                  <common-youtube-card-node node=node link-attrs={
+                    'data-company-id': content.id,
+                    'data-company-name': content.name,
+                  } />
                 </div>
               </for>
             </@nodes>

--- a/sites/oemmagazine.org/server/templates/content/company.marko
+++ b/sites/oemmagazine.org/server/templates/content/company.marko
@@ -121,7 +121,10 @@ $ const { id, type, pageNode } = data;
             <@nodes|{ nodes }| nodes=videos>
               <for|node| of=nodes>
                 <div class="node-list__node">
-                  <common-youtube-card-node node=node />
+                  <common-youtube-card-node node=node link-attrs={
+                    'data-company-id': content.id,
+                    'data-company-name': content.name,
+                  } />
                 </div>
               </for>
             </@nodes>

--- a/sites/packworld.com/server/templates/content/company.marko
+++ b/sites/packworld.com/server/templates/content/company.marko
@@ -121,7 +121,10 @@ $ const { id, type, pageNode } = data;
             <@nodes|{ nodes }| nodes=videos>
               <for|node| of=nodes>
                 <div class="node-list__node">
-                  <common-youtube-card-node node=node />
+                  <common-youtube-card-node node=node link-attrs={
+                    'data-company-id': content.id,
+                    'data-company-name': content.name,
+                  } />
                 </div>
               </for>
             </@nodes>

--- a/sites/profoodworld.com/server/templates/content/company.marko
+++ b/sites/profoodworld.com/server/templates/content/company.marko
@@ -121,7 +121,10 @@ $ const { id, type, pageNode } = data;
             <@nodes|{ nodes }| nodes=videos>
               <for|node| of=nodes>
                 <div class="node-list__node">
-                  <common-youtube-card-node node=node />
+                  <common-youtube-card-node node=node link-attrs={
+                    'data-company-id': content.id,
+                    'data-company-name': content.name,
+                  } />
                 </div>
               </for>
             </@nodes>


### PR DESCRIPTION
Ref [BCMS-293](https://southcomm.atlassian.net/browse/BCMS-293)

- [x] When clicking on a youtube link from the leaders data card, the company data isn't present in the data layer when processing the leadworks click trigger. Reported no tracking is being sent from card.
- [x] When clicking on a youtube link from an article page, the article's name/id are present instead of the company.
- [x] When clicking on a youtube link from a company page, the data is correct, but updates to resolve the two previous will likely require refactoring of code, affecting these links as well.