### PR TITLE
Remove dates from all Documents

### DIFF
--- a/sites/automationworld.com/server/components/nodes/components/dates.marko
+++ b/sites/automationworld.com/server/components/nodes/components/dates.marko
@@ -2,9 +2,9 @@ $ const { content, blockName } = input;
 
 <if(content.type === "event" || content.type === "webinar")>
   <div class=`${blockName}__content-event-dates`>
-      <marko-web-content-start-date tag="span" block-name=blockName obj=content />
-      <marko-web-content-end-date tag="span" block-name=blockName obj=content />
-    </div>
+    <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+    <marko-web-content-end-date tag="span" block-name=blockName obj=content />
+  </div>
 </if>
 <else-if(content.type !== "document")>
   <marko-web-content-published obj=content />

--- a/sites/automationworld.com/server/components/nodes/components/dates.marko
+++ b/sites/automationworld.com/server/components/nodes/components/dates.marko
@@ -1,11 +1,13 @@
 $ const { content, blockName } = input;
 
-<if(content.type === "event" || content.type === "webinar")>
-  <div class=`${blockName}__content-event-dates`>
-    <marko-web-content-start-date tag="span" block-name=blockName obj=content />
-    <marko-web-content-end-date tag="span" block-name=blockName obj=content />
-  </div>
+<if(content.type != "document")>
+  <if(content.type === "event" || content.type === "webinar")>
+    <div class=`${blockName}__content-event-dates`>
+      <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+      <marko-web-content-end-date tag="span" block-name=blockName obj=content />
+    </div>
+  </if>
+  <else>
+    <marko-web-content-published obj=content />
+  </else>
 </if>
-<else>
-  <marko-web-content-published obj=content />
-</else>

--- a/sites/automationworld.com/server/components/nodes/components/dates.marko
+++ b/sites/automationworld.com/server/components/nodes/components/dates.marko
@@ -1,13 +1,11 @@
 $ const { content, blockName } = input;
 
-<if(content.type != "document")>
-  <if(content.type === "event" || content.type === "webinar")>
-    <div class=`${blockName}__content-event-dates`>
+<if(content.type === "event" || content.type === "webinar")>
+  <div class=`${blockName}__content-event-dates`>
       <marko-web-content-start-date tag="span" block-name=blockName obj=content />
       <marko-web-content-end-date tag="span" block-name=blockName obj=content />
     </div>
-  </if>
-  <else>
-    <marko-web-content-published obj=content />
-  </else>
 </if>
+<else-if(content.type !== "document")>
+  <marko-web-content-published obj=content />
+</else-if>

--- a/sites/automationworld.com/server/templates/content/document.marko
+++ b/sites/automationworld.com/server/templates/content/document.marko
@@ -7,7 +7,7 @@ $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
 $ const displayCarousel = true;
-$ const displayPublishedDate = true;
+$ const displayPublishedDate = false;
 
 <marko-web-content-page-layout id=id type=type>
   <@head>
@@ -42,9 +42,11 @@ $ const displayPublishedDate = true;
               <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
               <common-supplier-disclaimer obj=content />
               <default-theme-content-attribution obj=content />
-              <default-theme-page-dates|{ blockName }|>
-                <marko-web-content-published block-name=blockName obj=content />
-              </default-theme-page-dates>
+              <if(displayPublishedDate)>
+                <default-theme-page-dates|{ blockName }|>
+                  <marko-web-content-published block-name=blockName obj=content />
+                </default-theme-page-dates>
+              </if>
             </div>
           </div>
         </@section>

--- a/sites/healthcarepackaging.com/server/components/nodes/components/dates.marko
+++ b/sites/healthcarepackaging.com/server/components/nodes/components/dates.marko
@@ -2,9 +2,9 @@ $ const { content, blockName } = input;
 
 <if(content.type === "event" || content.type === "webinar")>
   <div class=`${blockName}__content-event-dates`>
-      <marko-web-content-start-date tag="span" block-name=blockName obj=content />
-      <marko-web-content-end-date tag="span" block-name=blockName obj=content />
-    </div>
+    <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+    <marko-web-content-end-date tag="span" block-name=blockName obj=content />
+  </div>
 </if>
 <else-if(content.type !== "document")>
   <marko-web-content-published obj=content />

--- a/sites/healthcarepackaging.com/server/components/nodes/components/dates.marko
+++ b/sites/healthcarepackaging.com/server/components/nodes/components/dates.marko
@@ -1,11 +1,13 @@
 $ const { content, blockName } = input;
 
-<if(content.type === "event" || content.type === "webinar")>
-  <div class=`${blockName}__content-event-dates`>
-    <marko-web-content-start-date tag="span" block-name=blockName obj=content />
-    <marko-web-content-end-date tag="span" block-name=blockName obj=content />
-  </div>
+<if(content.type != "document")>
+  <if(content.type === "event" || content.type === "webinar")>
+    <div class=`${blockName}__content-event-dates`>
+      <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+      <marko-web-content-end-date tag="span" block-name=blockName obj=content />
+    </div>
+  </if>
+  <else>
+    <marko-web-content-published obj=content />
+  </else>
 </if>
-<else>
-  <marko-web-content-published obj=content />
-</else>

--- a/sites/healthcarepackaging.com/server/components/nodes/components/dates.marko
+++ b/sites/healthcarepackaging.com/server/components/nodes/components/dates.marko
@@ -1,13 +1,11 @@
 $ const { content, blockName } = input;
 
-<if(content.type != "document")>
-  <if(content.type === "event" || content.type === "webinar")>
-    <div class=`${blockName}__content-event-dates`>
+<if(content.type === "event" || content.type === "webinar")>
+  <div class=`${blockName}__content-event-dates`>
       <marko-web-content-start-date tag="span" block-name=blockName obj=content />
       <marko-web-content-end-date tag="span" block-name=blockName obj=content />
     </div>
-  </if>
-  <else>
-    <marko-web-content-published obj=content />
-  </else>
 </if>
+<else-if(content.type !== "document")>
+  <marko-web-content-published obj=content />
+</else-if>

--- a/sites/healthcarepackaging.com/server/templates/content/document.marko
+++ b/sites/healthcarepackaging.com/server/templates/content/document.marko
@@ -7,7 +7,7 @@ $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
 $ const displayCarousel = true;
-$ const displayPublishedDate = true;
+$ const displayPublishedDate = false;
 
 <marko-web-content-page-layout id=id type=type>
   <@head>
@@ -42,9 +42,11 @@ $ const displayPublishedDate = true;
               <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
               <common-supplier-disclaimer obj=content />
               <default-theme-content-attribution obj=content />
-              <default-theme-page-dates|{ blockName }|>
-                <marko-web-content-published block-name=blockName obj=content />
-              </default-theme-page-dates>
+              <if(displayPublishedDate)>
+                <default-theme-page-dates|{ blockName }|>
+                  <marko-web-content-published block-name=blockName obj=content />
+                </default-theme-page-dates>
+              </if>
             </div>
           </div>
         </@section>

--- a/sites/oemmagazine.org/server/components/nodes/components/dates.marko
+++ b/sites/oemmagazine.org/server/components/nodes/components/dates.marko
@@ -2,9 +2,9 @@ $ const { content, blockName } = input;
 
 <if(content.type === "event" || content.type === "webinar")>
   <div class=`${blockName}__content-event-dates`>
-      <marko-web-content-start-date tag="span" block-name=blockName obj=content />
-      <marko-web-content-end-date tag="span" block-name=blockName obj=content />
-    </div>
+    <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+    <marko-web-content-end-date tag="span" block-name=blockName obj=content />
+  </div>
 </if>
 <else-if(content.type !== "document")>
   <marko-web-content-published obj=content />

--- a/sites/oemmagazine.org/server/components/nodes/components/dates.marko
+++ b/sites/oemmagazine.org/server/components/nodes/components/dates.marko
@@ -1,11 +1,13 @@
 $ const { content, blockName } = input;
 
-<if(content.type === "event" || content.type === "webinar")>
-  <div class=`${blockName}__content-event-dates`>
-    <marko-web-content-start-date tag="span" block-name=blockName obj=content />
-    <marko-web-content-end-date tag="span" block-name=blockName obj=content />
-  </div>
+<if(content.type != "document")>
+  <if(content.type === "event" || content.type === "webinar")>
+    <div class=`${blockName}__content-event-dates`>
+      <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+      <marko-web-content-end-date tag="span" block-name=blockName obj=content />
+    </div>
+  </if>
+  <else>
+    <marko-web-content-published obj=content />
+  </else>
 </if>
-<else>
-  <marko-web-content-published obj=content />
-</else>

--- a/sites/oemmagazine.org/server/components/nodes/components/dates.marko
+++ b/sites/oemmagazine.org/server/components/nodes/components/dates.marko
@@ -1,13 +1,11 @@
 $ const { content, blockName } = input;
 
-<if(content.type != "document")>
-  <if(content.type === "event" || content.type === "webinar")>
-    <div class=`${blockName}__content-event-dates`>
+<if(content.type === "event" || content.type === "webinar")>
+  <div class=`${blockName}__content-event-dates`>
       <marko-web-content-start-date tag="span" block-name=blockName obj=content />
       <marko-web-content-end-date tag="span" block-name=blockName obj=content />
     </div>
-  </if>
-  <else>
-    <marko-web-content-published obj=content />
-  </else>
 </if>
+<else-if(content.type !== "document")>
+  <marko-web-content-published obj=content />
+</else-if>

--- a/sites/oemmagazine.org/server/templates/content/document.marko
+++ b/sites/oemmagazine.org/server/templates/content/document.marko
@@ -7,7 +7,7 @@ $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
 $ const displayCarousel = true;
-$ const displayPublishedDate = true;
+$ const displayPublishedDate = false;
 
 <marko-web-content-page-layout id=id type=type>
   <@head>
@@ -42,9 +42,11 @@ $ const displayPublishedDate = true;
               <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
               <common-supplier-disclaimer obj=content />
               <default-theme-content-attribution obj=content />
-              <default-theme-page-dates|{ blockName }|>
-                <marko-web-content-published block-name=blockName obj=content />
-              </default-theme-page-dates>
+              <if(displayPublishedDate)>
+                <default-theme-page-dates|{ blockName }|>
+                  <marko-web-content-published block-name=blockName obj=content />
+                </default-theme-page-dates>
+              </if>
             </div>
           </div>
         </@section>

--- a/sites/packworld.com/server/components/nodes/components/dates.marko
+++ b/sites/packworld.com/server/components/nodes/components/dates.marko
@@ -2,9 +2,9 @@ $ const { content, blockName } = input;
 
 <if(content.type === "event" || content.type === "webinar")>
   <div class=`${blockName}__content-event-dates`>
-      <marko-web-content-start-date tag="span" block-name=blockName obj=content />
-      <marko-web-content-end-date tag="span" block-name=blockName obj=content />
-    </div>
+    <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+    <marko-web-content-end-date tag="span" block-name=blockName obj=content />
+  </div>
 </if>
 <else-if(content.type !== "document")>
   <marko-web-content-published obj=content />

--- a/sites/packworld.com/server/components/nodes/components/dates.marko
+++ b/sites/packworld.com/server/components/nodes/components/dates.marko
@@ -1,11 +1,13 @@
 $ const { content, blockName } = input;
 
-<if(content.type === "event" || content.type === "webinar")>
-  <div class=`${blockName}__content-event-dates`>
-    <marko-web-content-start-date tag="span" block-name=blockName obj=content />
-    <marko-web-content-end-date tag="span" block-name=blockName obj=content />
-  </div>
+<if(content.type != "document")>
+  <if(content.type === "event" || content.type === "webinar")>
+    <div class=`${blockName}__content-event-dates`>
+      <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+      <marko-web-content-end-date tag="span" block-name=blockName obj=content />
+    </div>
+  </if>
+  <else>
+    <marko-web-content-published obj=content />
+  </else>
 </if>
-<else>
-  <marko-web-content-published obj=content />
-</else>

--- a/sites/packworld.com/server/components/nodes/components/dates.marko
+++ b/sites/packworld.com/server/components/nodes/components/dates.marko
@@ -1,13 +1,11 @@
 $ const { content, blockName } = input;
 
-<if(content.type != "document")>
-  <if(content.type === "event" || content.type === "webinar")>
-    <div class=`${blockName}__content-event-dates`>
+<if(content.type === "event" || content.type === "webinar")>
+  <div class=`${blockName}__content-event-dates`>
       <marko-web-content-start-date tag="span" block-name=blockName obj=content />
       <marko-web-content-end-date tag="span" block-name=blockName obj=content />
     </div>
-  </if>
-  <else>
-    <marko-web-content-published obj=content />
-  </else>
 </if>
+<else-if(content.type !== "document")>
+  <marko-web-content-published obj=content />
+</else-if>

--- a/sites/packworld.com/server/templates/content/document.marko
+++ b/sites/packworld.com/server/templates/content/document.marko
@@ -7,7 +7,7 @@ $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
 $ const displayCarousel = true;
-$ const displayPublishedDate = true;
+$ const displayPublishedDate = false;
 
 <marko-web-content-page-layout id=id type=type>
   <@head>
@@ -42,9 +42,11 @@ $ const displayPublishedDate = true;
               <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
               <common-supplier-disclaimer obj=content />
               <default-theme-content-attribution obj=content />
-              <default-theme-page-dates|{ blockName }|>
-                <marko-web-content-published block-name=blockName obj=content />
-              </default-theme-page-dates>
+              <if(displayPublishedDate)>
+                <default-theme-page-dates|{ blockName }|>
+                  <marko-web-content-published block-name=blockName obj=content />
+                </default-theme-page-dates>
+              </if>
             </div>
           </div>
         </@section>

--- a/sites/profoodworld.com/server/components/nodes/components/dates.marko
+++ b/sites/profoodworld.com/server/components/nodes/components/dates.marko
@@ -2,9 +2,9 @@ $ const { content, blockName } = input;
 
 <if(content.type === "event" || content.type === "webinar")>
   <div class=`${blockName}__content-event-dates`>
-      <marko-web-content-start-date tag="span" block-name=blockName obj=content />
-      <marko-web-content-end-date tag="span" block-name=blockName obj=content />
-    </div>
+    <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+    <marko-web-content-end-date tag="span" block-name=blockName obj=content />
+  </div>
 </if>
 <else-if(content.type !== "document")>
   <marko-web-content-published obj=content />

--- a/sites/profoodworld.com/server/components/nodes/components/dates.marko
+++ b/sites/profoodworld.com/server/components/nodes/components/dates.marko
@@ -1,11 +1,13 @@
 $ const { content, blockName } = input;
 
-<if(content.type === "event" || content.type === "webinar")>
-  <div class=`${blockName}__content-event-dates`>
-    <marko-web-content-start-date tag="span" block-name=blockName obj=content />
-    <marko-web-content-end-date tag="span" block-name=blockName obj=content />
-  </div>
+<if(content.type != "document")>
+  <if(content.type === "event" || content.type === "webinar")>
+    <div class=`${blockName}__content-event-dates`>
+      <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+      <marko-web-content-end-date tag="span" block-name=blockName obj=content />
+    </div>
+  </if>
+  <else>
+    <marko-web-content-published obj=content />
+  </else>
 </if>
-<else>
-  <marko-web-content-published obj=content />
-</else>

--- a/sites/profoodworld.com/server/components/nodes/components/dates.marko
+++ b/sites/profoodworld.com/server/components/nodes/components/dates.marko
@@ -1,13 +1,11 @@
 $ const { content, blockName } = input;
 
-<if(content.type != "document")>
-  <if(content.type === "event" || content.type === "webinar")>
-    <div class=`${blockName}__content-event-dates`>
+<if(content.type === "event" || content.type === "webinar")>
+  <div class=`${blockName}__content-event-dates`>
       <marko-web-content-start-date tag="span" block-name=blockName obj=content />
       <marko-web-content-end-date tag="span" block-name=blockName obj=content />
     </div>
-  </if>
-  <else>
-    <marko-web-content-published obj=content />
-  </else>
 </if>
+<else-if(content.type !== "document")>
+  <marko-web-content-published obj=content />
+</else-if>

--- a/sites/profoodworld.com/server/templates/content/document.marko
+++ b/sites/profoodworld.com/server/templates/content/document.marko
@@ -7,7 +7,7 @@ $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
 $ const displayCarousel = true;
-$ const displayPublishedDate = true;
+$ const displayPublishedDate = false;
 
 <marko-web-content-page-layout id=id type=type>
   <@head>
@@ -42,9 +42,11 @@ $ const displayPublishedDate = true;
               <marko-web-content-teaser tag="p" class="page-wrapper__deck" obj=content />
               <common-supplier-disclaimer obj=content />
               <default-theme-content-attribution obj=content />
-              <default-theme-page-dates|{ blockName }|>
-                <marko-web-content-published block-name=blockName obj=content />
-              </default-theme-page-dates>
+              <if(displayPublishedDate)>
+                <default-theme-page-dates|{ blockName }|>
+                  <marko-web-content-published block-name=blockName obj=content />
+                </default-theme-page-dates>
+              </if>
             </div>
           </div>
         </@section>


### PR DESCRIPTION
Wrapped the date on content landing pages in a displayPublishedDate check, set to false.  Also checked for content type on dates.marko to ensure they’ll be removed everywhere (card/list/etc)