### PR TITLE
Blockquote, pullquote & drop-cap styling

### DIFF
--- a/packages/common/scss/common.scss
+++ b/packages/common/scss/common.scss
@@ -101,3 +101,48 @@ $theme-site-header-breakpoints: (
     margin-top: 1.5rem;
   }
 }
+
+.page-contents__content-body blockquote {
+  display: block;
+  padding: 20px;
+  border-left: 8px solid #d2d2d2;
+  background: #e3e3e3;
+}
+
+.page-contents__content-body blockquote p {
+  margin-bottom: 0;
+}
+
+.page-contents__content-body .pullquote {
+  position: relative;
+  float: right;
+  width: 50%;
+  max-width: 50%;
+  padding: 12px 0 12px 12px;
+  margin: 6px 0 6px 12px;
+  font-size: 18.75px;
+  color: #6f6f6f;
+}
+
+.page-contents__content-body .pullquote:before {
+  position: absolute;
+  left: 0;
+  z-index: -1;
+  font-size: 8em;
+  line-height: .6em;
+  content: "“";
+  color: #dedede;
+}
+
+.page-contents__content-body .drop-caps:first-letter {
+  float: left;
+  padding: 0;
+  margin: -.05em .125em 0 0;
+  font-size: 115px;
+  font-weight: 700;
+  line-height: .8;
+}
+
+.page-contents__content-body .drop-caps {
+  display: inherit;
+}


### PR DESCRIPTION
Shamelessly stolen from icarus’ css.

This is missing globally, so if this is approved, I can replicate it for EBM, ACBM & INDM repos as well.  If there's a better way of adding this, or if it should be in a different file, just let me know! :)

----

**Pull-quote:**

![Screen Shot 2020-05-04 at 3 07 43 PM](https://user-images.githubusercontent.com/12496550/81009850-ffcadc00-8e1a-11ea-9148-75c45ab3efc9.png)

**Blockquote:**

![Screen Shot 2020-05-04 at 1 51 20 PM](https://user-images.githubusercontent.com/12496550/81009885-0f4a2500-8e1b-11ea-956a-20606e5c79b1.png)

**Drop-cap:**

![Screen Shot 2020-05-04 at 2 43 35 PM](https://user-images.githubusercontent.com/12496550/81009912-15d89c80-8e1b-11ea-90a9-4f12d4227784.png)
