### PR TITLE
Disallow load-more in robots.txt

### DIFF
--- a/sites/packworld.com/server/public/robots.txt
+++ b/sites/packworld.com/server/public/robots.txt
@@ -3,6 +3,7 @@
 
 User-agent: *
 Disallow: /__load-more
+Disallow: /__load-more/
 
 Sitemap: https://www.packworld.com/sitemap.xml
 Sitemap: https://www.packworld.com/sitemap-google-news.xml


### PR DESCRIPTION
Testing this change on packworld.com before replicating for other sites.

So here's my thought-process.... PMMI (and others) are complaining about un-related teasers showing up in search results.  For example, searching "Silver Springs" on packworld.com shows the same teaser for multiple items, because it's crawling the load-more.  

We already have `Disallow: /__load-more` in robots.txt so it SHOULDN'T be crawling those teasers, but then I looked at the request and noticed the load-more is actually `/__load-more/?input=`, which means `Disallow: /__load-more` won't work.  I'm hoping that by adding a `/` it will stop crawling the load-more.  

![Screen Shot 2020-05-11 at 1 19 52 PM](https://user-images.githubusercontent.com/12496550/81597528-7facf500-938b-11ea-9344-0bf960e52aca.png)

google robots.txt documentation: 
https://developers.google.com/search/reference/robots_txt
![Screen Shot 2020-05-11 at 1 22 29 PM](https://user-images.githubusercontent.com/12496550/81597558-89365d00-938b-11ea-8dc1-2e0d16e2d276.png)
