### PR TITLE
Move Reprints link in navigation.js

### DIFF
--- a/sites/automationworld.com/config/navigation.js
+++ b/sites/automationworld.com/config/navigation.js
@@ -52,12 +52,12 @@ module.exports = {
       items: [
         { href: 'https://pmmi.dragonforms.com/loading.do?pk=AWMagNav&oly_enc_id=@{encrypted_customer_id}@&omedasite=PAWnew', label: 'Subscribe', target: '_blank' },
         { href: 'https://www.pmmimediagroup.com/aw/automation-world', label: 'Advertise', target: '_blank' },
+        { href: 'https://www.pmmimediagroup.com/aw/reprints-and-permissions', label: 'Reprints' },
         { href: '/page/aw-about-us', label: 'About' },
         { href: '/page/aw-contact-us', label: 'Contact' },
         { href: 'https://www.pmmimediagroup.com/privacy', label: 'Privacy', target: '_blank' },
         { href: '/page/aw-terms-use', label: 'Terms of Use' },
         { href: 'https://www.pmmimediagroup.com/advertising-terms-conditions', label: 'Advertising Terms & Conditions', target: '_blank' },
-        { href: '/aw/reprints-and-permissions', label: 'Reprints' },
       ],
     },
   ],

--- a/sites/healthcarepackaging.com/config/navigation.js
+++ b/sites/healthcarepackaging.com/config/navigation.js
@@ -54,12 +54,12 @@ module.exports = {
       items: [
         { href: 'https://pmmi.dragonforms.com/loading.do?pk=HCPMagNav&oly_enc_id=@{encrypted_customer_id}@&omedasite=HCPnew', label: 'Subscribe', target: '_blank' },
         { href: 'https://www.pmmimediagroup.com/hcp/healthcare-packaging', label: 'Advertise', target: '_blank' },
+        { href: 'https://www.pmmimediagroup.com/hcp/reprints-and-permissions', label: 'Reprints' },
         { href: '/page/hcp-about-us', label: 'About' },
         { href: '/page/hcp-contact-us', label: 'Contact' },
         { href: 'https://www.pmmimediagroup.com/privacy', label: 'Privacy', target: '_blank' },
         { href: '/page/hcp-terms-use', label: 'Terms of Use' },
         { href: 'https://www.pmmimediagroup.com/advertising-terms-conditions', label: 'Advertising Terms & Conditions', target: '_blank' },
-        { href: '/pw/reprints-and-permissions', label: 'Reprints' },
       ],
     },
   ],

--- a/sites/oemmagazine.org/config/navigation.js
+++ b/sites/oemmagazine.org/config/navigation.js
@@ -50,12 +50,12 @@ module.exports = {
       items: [
         { href: 'https://pmmi.dragonforms.com/init.do?pk=OEMMagNav&oly_enc_id=@{encrypted_customer_id}@&omedasite=OEMnew', label: 'Subscribe', target: '_blank' },
         { href: 'https://www.pmmimediagroup.com/oem', label: 'Advertise', target: '_blank' },
+        { href: 'https://www.pmmimediagroup.com/ppoem/reprints-and-permissions', label: 'Reprints' },
         { href: '/page/oem-about-us', label: 'About' },
         { href: '/page/oem-contact-us', label: 'Contact' },
         { href: 'https://www.pmmimediagroup.com/privacy', label: 'Privacy', target: '_blank' },
         { href: '/page/oem-terms-use', label: 'Terms of Use' },
         { href: 'https://www.pmmimediagroup.com/advertising-terms-conditions', label: 'Advertising Terms & Conditions', target: '_blank' },
-        { href: '/ppoem/reprints-and-permissions', label: 'Reprints' },
       ],
     },
   ],

--- a/sites/packworld.com/config/navigation.js
+++ b/sites/packworld.com/config/navigation.js
@@ -55,12 +55,12 @@ module.exports = {
       items: [
         { href: 'https://pmmi.dragonforms.com/loading.do?pk=PWMagNav&oly_enc_id=@{encrypted_customer_id}@&omedasite=PPWnew', label: 'Subscribe', target: '_blank' },
         { href: 'https://www.pmmimediagroup.com/pw/packaging-world', label: 'Advertise', target: '_blank' },
+        { href: 'https://www.pmmimediagroup.com/pw/reprints-and-permissions', label: 'Reprints' },
         { href: '/page/pw-about-us', label: 'About' },
         { href: '/page/pw-contact-us', label: 'Contact' },
         { href: 'https://www.pmmimediagroup.com/privacy', label: 'Privacy', target: '_blank' },
         { href: '/page/pw-terms-use', label: 'Terms of Use' },
         { href: 'https://www.pmmimediagroup.com/advertising-terms-conditions', label: 'Advertising Terms & Conditions', target: '_blank' },
-        { href: '/pw/reprints-and-permissions', label: 'Reprints' },
       ],
     },
   ],

--- a/sites/profoodworld.com/config/navigation.js
+++ b/sites/profoodworld.com/config/navigation.js
@@ -56,12 +56,12 @@ module.exports = {
       items: [
         { href: 'https://pmmi.dragonforms.com/loading.do?pk=PFWMagNav&oly_enc_id=@{encrypted_customer_id}@&omedasite=PPFWnew ', label: 'Subscribe', target: '_blank' },
         { href: 'https://www.pmmimediagroup.com/pfw/profood-world', label: 'Advertise', target: '_blank' },
+        { href: 'https://www.pmmimediagroup.com/pfw/reprints-and-permissions', label: 'Reprints' },
         { href: '/page/pfw-about-us', label: 'About' },
         { href: '/page/pfw-contact-us', label: 'Contact' },
         { href: 'https://www.pmmimediagroup.com/privacy', label: 'Privacy', target: '_blank' },
         { href: '/page/pfw-terms-use', label: 'Terms of Use' },
         { href: 'https://www.pmmimediagroup.com/advertising-terms-conditions', label: 'Advertising Terms & Conditions', target: '_blank' },
-        { href: '/pfw/reprints-and-permissions', label: 'Reprints' },
       ],
     },
   ],


### PR DESCRIPTION
Moved up to be below “Advertise” and point to the pmmimediagroup domain.   There are redirects in place so they don’t 404 but in the meantime the link should be updated.