### PR TITLE
Temporarily remove Digital Editions from nav

### DIFF
--- a/sites/automationworld.com/config/navigation.js
+++ b/sites/automationworld.com/config/navigation.js
@@ -44,7 +44,7 @@ module.exports = {
         { href: '/videos', label: 'Videos' },
         { href: '/podcasts', label: 'Podcasts' },
         { href: '/webinars', label: 'Webinars' },
-        { href: '/page/digital-editions', label: 'Digital Editions' },
+        // { href: '/page/digital-editions', label: 'Digital Editions' },
       ],
     },
     {

--- a/sites/healthcarepackaging.com/config/navigation.js
+++ b/sites/healthcarepackaging.com/config/navigation.js
@@ -46,7 +46,7 @@ module.exports = {
         { href: '/videos', label: 'Videos' },
         { href: 'https://www.pmmi.org/hall-of-fame', label: 'Hall of Fame', target: '_blank' },
         { href: '/webinars', label: 'Webinars' },
-        { href: '/page/digital-editions', label: 'Digital Editions' },
+        // { href: '/page/digital-editions', label: 'Digital Editions' },
       ],
     },
     {

--- a/sites/oemmagazine.org/config/navigation.js
+++ b/sites/oemmagazine.org/config/navigation.js
@@ -42,7 +42,7 @@ module.exports = {
         { href: '/page/magazine', label: 'Magazine' },
         { href: '/leaders', label: 'Tech Trendsetters' },
         { href: '/videos', label: 'Videos' },
-        { href: '/page/digital-editions', label: 'Digital Editions' },
+        // { href: '/page/digital-editions', label: 'Digital Editions' },
       ],
     },
     {

--- a/sites/packworld.com/config/navigation.js
+++ b/sites/packworld.com/config/navigation.js
@@ -47,7 +47,7 @@ module.exports = {
         { href: '/page/packaging-associations', label: 'Packaging Associations' },
         { href: 'https://www.pmmi.org/hall-of-fame', label: 'Hall of Fame', target: '_blank' },
         { href: '/webinars', label: 'Webinars' },
-        { href: '/page/digital-editions', label: 'Digital Editions' },
+        // { href: '/page/digital-editions', label: 'Digital Editions' },
       ],
     },
     {

--- a/sites/profoodworld.com/config/navigation.js
+++ b/sites/profoodworld.com/config/navigation.js
@@ -48,7 +48,7 @@ module.exports = {
         { href: 'https://www.opxleadershipnetwork.org', label: 'OpX Leadership Network', target: '_blank' },
         { href: '/page/awards-sema', label: 'Sustainability Awards' },
         { href: '/page/awards-mia', label: 'Manufacturing Awards' },
-        { href: '/page/digital-editions', label: 'Digital Editions' },
+        // { href: '/page/digital-editions', label: 'Digital Editions' },
       ],
     },
     {


### PR DESCRIPTION
Shortly after we added them, they decided they wanted to remove them for the moment, and display them at a later date.  Commenting them out for now.