### PR TITLE
/events changed to /supplier-events

### DIFF
--- a/sites/automationworld.com/server/routes/published-content.js
+++ b/sites/automationworld.com/server/routes/published-content.js
@@ -1,4 +1,4 @@
-const events = require('../templates/published-content/events');
+const events = require('../templates/published-content/supplier-events');
 const webinars = require('../templates/published-content/webinars');
 const whitePapers = require('../templates/published-content/white-papers');
 const videos = require('../templates/published-content/videos');
@@ -6,7 +6,7 @@ const podcasts = require('../templates/published-content/podcasts');
 const documents = require('../templates/published-content/documents');
 
 module.exports = (app) => {
-  app.get('/events', (_, res) => { res.marko(events); });
+  app.get('/supplier-events', (_, res) => { res.marko(events); });
   app.get('/webinars', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });

--- a/sites/automationworld.com/server/templates/published-content/supplier-events.marko
+++ b/sites/automationworld.com/server/templates/published-content/supplier-events.marko
@@ -5,7 +5,7 @@ import queryFragment from "../../graphql/fragments/content-list";
 $ const { config } = out.global;
 
 $ const type = "published-content";
-$ const title = "Events";
+$ const title = "Supplier Events";
 $ const description = defaultDescription(title, config);
 $ const now = (new Date()).valueOf();
 

--- a/sites/healthcarepackaging.com/server/routes/published-content.js
+++ b/sites/healthcarepackaging.com/server/routes/published-content.js
@@ -1,4 +1,4 @@
-const events = require('../templates/published-content/events');
+const events = require('../templates/published-content/supplier-events');
 const webinars = require('../templates/published-content/webinars');
 const whitePapers = require('../templates/published-content/white-papers');
 const videos = require('../templates/published-content/videos');
@@ -6,7 +6,7 @@ const podcasts = require('../templates/published-content/podcasts');
 const documents = require('../templates/published-content/documents');
 
 module.exports = (app) => {
-  app.get('/events', (_, res) => { res.marko(events); });
+  app.get('/supplier-events', (_, res) => { res.marko(events); });
   app.get('/webinars', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });

--- a/sites/healthcarepackaging.com/server/templates/published-content/supplier-events.marko
+++ b/sites/healthcarepackaging.com/server/templates/published-content/supplier-events.marko
@@ -5,7 +5,7 @@ import queryFragment from "../../graphql/fragments/content-list";
 $ const { config } = out.global;
 
 $ const type = "published-content";
-$ const title = "Events";
+$ const title = "Supplier Events";
 $ const description = defaultDescription(title, config);
 $ const now = (new Date()).valueOf();
 

--- a/sites/oemmagazine.org/server/routes/published-content.js
+++ b/sites/oemmagazine.org/server/routes/published-content.js
@@ -1,4 +1,4 @@
-const events = require('../templates/published-content/events');
+const events = require('../templates/published-content/supplier-events');
 const webinars = require('../templates/published-content/webinars');
 const whitePapers = require('../templates/published-content/white-papers');
 const videos = require('../templates/published-content/videos');
@@ -6,7 +6,7 @@ const podcasts = require('../templates/published-content/podcasts');
 const documents = require('../templates/published-content/documents');
 
 module.exports = (app) => {
-  app.get('/events', (_, res) => { res.marko(events); });
+  app.get('/supplier-events', (_, res) => { res.marko(events); });
   app.get('/webinars', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });

--- a/sites/oemmagazine.org/server/templates/published-content/supplier-events.marko
+++ b/sites/oemmagazine.org/server/templates/published-content/supplier-events.marko
@@ -5,7 +5,7 @@ import queryFragment from "../../graphql/fragments/content-list";
 $ const { config } = out.global;
 
 $ const type = "published-content";
-$ const title = "Events";
+$ const title = "Supplier Events";
 $ const description = defaultDescription(title, config);
 $ const now = (new Date()).valueOf();
 

--- a/sites/packworld.com/server/routes/published-content.js
+++ b/sites/packworld.com/server/routes/published-content.js
@@ -1,4 +1,4 @@
-const events = require('../templates/published-content/events');
+const events = require('../templates/published-content/supplier-events');
 const webinars = require('../templates/published-content/webinars');
 const whitePapers = require('../templates/published-content/white-papers');
 const videos = require('../templates/published-content/videos');
@@ -6,7 +6,7 @@ const podcasts = require('../templates/published-content/podcasts');
 const documents = require('../templates/published-content/documents');
 
 module.exports = (app) => {
-  app.get('/events', (_, res) => { res.marko(events); });
+  app.get('/supplier-events', (_, res) => { res.marko(events); });
   app.get('/webinars', (_, res) => { res.marko(webinars); });
   app.get('/white-papers', (_, res) => { res.marko(whitePapers); });
   app.get('/videos', (_, res) => { res.marko(videos); });

--- a/sites/packworld.com/server/templates/published-content/supplier-events.marko
+++ b/sites/packworld.com/server/templates/published-content/supplier-events.marko
@@ -5,7 +5,7 @@ import queryFragment from "../../graphql/fragments/content-list";
 $ const { config } = out.global;
 
 $ const type = "published-content";
-$ const title = "Events";
+$ const title = "Supplier Events";
 $ const description = defaultDescription(title, config);
 $ const now = (new Date()).valueOf();
 


### PR DESCRIPTION
Updating the Events page to ‘Supplier Events’ per Jen in BCMS-709
![Screen Shot 2020-06-08 at 1 49 38 PM](https://user-images.githubusercontent.com/12496550/84070085-2d162700-a991-11ea-8fac-a613bc3c0dfb.png)
![Screen Shot 2020-06-08 at 2 05 19 PM](https://user-images.githubusercontent.com/12496550/84070088-2e475400-a991-11ea-84a3-aefa62f2ba5a.png)
