### PR TITLE
Add row to homepage & create new /products page

### DIFF
--- a/sites/healthcarepackaging.com/server/routes/published-content.js
+++ b/sites/healthcarepackaging.com/server/routes/published-content.js
@@ -4,6 +4,7 @@ const whitePapers = require('../templates/published-content/white-papers');
 const videos = require('../templates/published-content/videos');
 const podcasts = require('../templates/published-content/podcasts');
 const documents = require('../templates/published-content/documents');
+const products = require('../templates/published-content/products');
 
 module.exports = (app) => {
   app.get('/supplier-events', (_, res) => { res.marko(events); });
@@ -12,4 +13,5 @@ module.exports = (app) => {
   app.get('/videos', (_, res) => { res.marko(videos); });
   app.get('/podcasts', (_, res) => { res.marko(podcasts); });
   app.get('/downloads', (_, res) => { res.marko(documents); });
+  app.get('/products', (_, res) => { res.marko(products); });
 };

--- a/sites/healthcarepackaging.com/server/templates/index.marko
+++ b/sites/healthcarepackaging.com/server/templates/index.marko
@@ -126,6 +126,48 @@ $ const { id, alias, name, pageNode } = data;
       </div>
     </div>
 
+    <div class="row">
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "quick-hits", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/quick-hits">Quick Hits</marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="all-published-content"
+          params={ contentTypes: ["Product"], limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/products">Products</marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "supplier-news", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/supplier-news">Supplier News</marko-web-link>
+            </@header>
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 page-rail">
+        <marko-web-gtm-slot prefix=site.get("gtm.slotPrefix") name="home-04-tall-right" modifiers=["in-card"] />
+      </div>
+    </div>
+
     <marko-web-query|{ nodes }|
       name="website-optioned-content"
       params={ sectionAlias: "home", optionName: "Pinned", limit: 5, skip: 9, requiresImage: true, queryFragment }

--- a/sites/healthcarepackaging.com/server/templates/published-content/products.marko
+++ b/sites/healthcarepackaging.com/server/templates/published-content/products.marko
@@ -1,0 +1,49 @@
+import defaultDescription from "@base-cms/marko-web/utils/published-content/description";
+import GAM from "../../../config/gam";
+import queryFragment from "../../graphql/fragments/content-list";
+
+$ const { config } = out.global;
+
+$ const type = "published-content";
+$ const title = "Products";
+$ const description = defaultDescription(title, config);
+
+<marko-web-default-page-layout type=type title=title description=description>
+  <@head>
+    <marko-web-gtm-default-context|{ context }| type=type>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-default-context>
+  </@head>
+  <@page>
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-page-wrapper class="mb-block">
+      <@section>
+        <div class="row">
+          <div class="col">
+            <default-theme-breadcrumbs-with-home>
+              <@item>${title}</@item>
+            </default-theme-breadcrumbs-with-home>
+            <h1 class="page-wrapper__title">${title}</h1>
+            <div class="page-wrapper__deck">${description}</div>
+          </div>
+        </div>
+      </@section>
+    </marko-web-page-wrapper>
+
+    <marko-web-query|{ nodes }|
+      name="all-published-content"
+      params={ contentTypes: ["Product"], limit: 10, queryFragment }
+    >
+      <website-content-card-deck-flow nodes=nodes />
+    </marko-web-query>
+  </@page>
+  <@below-page>
+    <marko-web-load-more
+      component-name="content-card-deck-flow"
+      fragment-name="content-list"
+      query-name="all-published-content"
+      query-params={ contentTypes: ["Product"], limit: 10, skip: 10 }
+      page-input={ for: "published-content" }
+    />
+  </@below-page>
+</marko-web-default-page-layout>


### PR DESCRIPTION
Update homepage of HCP to include a new row:
- New section "Quick Hits" created, content scheduled based on "Quick Hits" Label.  
- "Products" column that pulls all published Products with landing page /products created for block title to link off to.  
- Existing section "Supplier News"

![Screen Shot 2020-06-11 at 10 18 30 AM](https://user-images.githubusercontent.com/12496550/84405474-c9c50880-abcd-11ea-96a7-a93396a9047d.png)
![Screen Shot 2020-06-11 at 10 18 23 AM](https://user-images.githubusercontent.com/12496550/84405482-cd588f80-abcd-11ea-866f-f070af5021d0.png)
