### PR TITLE
Modify products block on company profile pages

### DIFF
--- a/packages/common/components/nodes/featured-products-card.marko
+++ b/packages/common/components/nodes/featured-products-card.marko
@@ -1,0 +1,43 @@
+import { getAsArray, getAsObject, get } from "@base-cms/object-path";
+
+$ const content = getAsObject(input, "node");
+$ const primaryImage = getAsObject(content, "primaryImage");
+$ const displayImage = input.displayImage != null ? input.displayImage : true;
+$ const title = get(content, "linkText") || get(content, "shortName");
+$ const withTeaser = input.withTeaser != null ? input.withTeaser : true;
+$ const { linkAttrs } = input;
+
+<marko-web-node
+  type=`${content.type}-content`
+  image-position="top"
+  card=true
+  full-height=true
+  attrs=input.attrs
+>
+  <if(displayImage)>
+    <@image
+      src=primaryImage.src
+      alt=primaryImage.alt
+      is-logo=primaryImage.isLogo
+      fluid=true
+      ar="21:9"
+      width=(input.imageWidth || 300)
+      link={ href: get(content, "siteContext.path") }
+    />
+  </if>
+  <@body>
+  <@title tag="h5" modifiers=input.titleModifiers>
+    <marko-core-text value=title>
+      <@link href=content.siteContext.path />
+    </marko-core-text>
+  </@title>
+  <@text modifiers=["teaser"] show=(withTeaser && content.teaser)>
+    <marko-web-content-teaser tag=null obj=content link={ attrs: linkAttrs } />
+  </@text>
+  </@body>
+  <@footer>
+    <@left|{ blockName }|>
+      <marko-web-content-published block-name=blockName obj=content />
+    </@left>
+  </@footer>
+</marko-web-node>

--- a/packages/common/components/nodes/marko.json
+++ b/packages/common/components/nodes/marko.json
@@ -9,6 +9,19 @@
       "template": "./author-card.marko",
       "@node": "object",
       "@with-email": "boolean"
+    },
+    "common-featured-products-card-node": {
+      "template": "./featured-products-card.marko",
+      "@node": "object",
+      "@image-width": {
+        "type": "number",
+        "default-value": 300
+      },
+      "@with-teaser": {
+        "type": "boolean",
+        "default-value": true
+      },
+      "@link-attrs": "object"
     }
   }
 }

--- a/packages/shared/components/page-wrappers/content/leader.marko
+++ b/packages/shared/components/page-wrappers/content/leader.marko
@@ -68,19 +68,19 @@ $ const { id, type, content } = input;
       name="all-company-content"
       params={
         companyId: id,
-        includeContentTypes: ["Product"],
+        includeContentTypes: ["Promotion"],
         queryFragment,
         limit: 4,
       }
     >
       <marko-web-node-list class="mt-block">
         <@header>
-          Products
+          Featured Products
         </@header>
         <@nodes|{ nodes: items }| nodes=nodes>
           <default-theme-card-deck-flow cols=2 nodes=items>
             <@slot|{ node, index }|>
-              <shared-content-card-node
+              <common-featured-products-card-node
                 image-width=340
                 node=node
               />


### PR DESCRIPTION
PMMI would like the Products block on company profile pages to match the functionality of the “Featured Products” block on the leaders pop-out card.  Therefore, I swapped out the content type from Product to Promotion and created a new `featured-products-card` component that displays the `primaryImage`, `linkText` (`shortName` fallback), `teaser`, and `publishedDate`.

![image](https://user-images.githubusercontent.com/12496550/85135387-9f91cd00-b203-11ea-905b-84ef21925285.png)
