### PR TITLE
Remove publishedDate query on image carousel

### DIFF
--- a/sites/automationworld.com/server/templates/content/index.marko
+++ b/sites/automationworld.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
+                <if(images.length > 1)>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/cobotspot.packworld.com/server/templates/content/index.marko
+++ b/sites/cobotspot.packworld.com/server/templates/content/index.marko
@@ -62,7 +62,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
+                <if(images.length > 1)>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/healthcarepackaging.com/server/templates/content/index.marko
+++ b/sites/healthcarepackaging.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
+                <if(images.length > 1)>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/oemmagazine.org/server/templates/content/index.marko
+++ b/sites/oemmagazine.org/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
+                <if(images.length > 1)>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/packworld.com/server/templates/content/index.marko
+++ b/sites/packworld.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
+                <if(images.length > 1)>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/profoodworld.com/server/templates/content/index.marko
+++ b/sites/profoodworld.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1 && (content.status === 1 && content.published < new Date(2019, 9, 30)))>
+                <if(images.length > 1)>
                   <common-image-slider images=images />
                 </if>
                 <else>


### PR DESCRIPTION
They’d like to apply the existing carousel on all applicable content regardless of published date.  Offered them the new PhotoSwipe layout instead, but Zanzy said she’s fine with the existing one for now.  Changes stashed, in case they change their mind down the road.

![image](https://user-images.githubusercontent.com/12496550/87981370-c3faf680-ca9a-11ea-9492-cf22915a21f0.png)
