### PR TITLE
Don’t display carousel between 10/30/2019 and 07/21/2020

### DIFF
--- a/sites/automationworld.com/server/templates/content/index.marko
+++ b/sites/automationworld.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && (content.published < new Date(2019, 9, 30) || content.published > new Date(2020, 6, 21)))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/cobotspot.packworld.com/server/templates/content/index.marko
+++ b/sites/cobotspot.packworld.com/server/templates/content/index.marko
@@ -62,7 +62,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && (content.published < new Date(2019, 9, 30) || content.published > new Date(2020, 6, 21)))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/healthcarepackaging.com/server/templates/content/index.marko
+++ b/sites/healthcarepackaging.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && (content.published < new Date(2019, 9, 30) || content.published > new Date(2020, 6, 21)))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/oemmagazine.org/server/templates/content/index.marko
+++ b/sites/oemmagazine.org/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && (content.published < new Date(2019, 9, 30) || content.published > new Date(2020, 6, 21)))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/packworld.com/server/templates/content/index.marko
+++ b/sites/packworld.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && (content.published < new Date(2019, 9, 30) || content.published > new Date(2020, 6, 21)))>
                   <common-image-slider images=images />
                 </if>
                 <else>

--- a/sites/profoodworld.com/server/templates/content/index.marko
+++ b/sites/profoodworld.com/server/templates/content/index.marko
@@ -68,7 +68,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
               <else-if(displayCarousel)>
                 $ const images = getAsArray(content, "images.edges").map(({ node }) => node);
-                <if(images.length > 1)>
+                <if(images.length > 1 && (content.published < new Date(2019, 9, 30) || content.published > new Date(2020, 6, 21)))>
                   <common-image-slider images=images />
                 </if>
                 <else>


### PR DESCRIPTION
Relates to https://github.com/base-cms-websites/pmmi-media-group/pull/150

The editors have requested a change to the published date query, so that only content since the #150 change has the new carousel.  That way, they don’t have to go back and alter old content.