### PR TITLE
Add `recaptcha_site_key` to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ x-env-defaults: &env
   NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY-(unset)}
   NODE_ENV: development
   # @todo the recaptcha values should be removed (?) once contact-us is moved to core.
+  RECAPTCHA_SITE_KEY: ${RECAPTCHA_SITE_KEY-(unset)}
   RECAPTCHA_SECRET_KEY: ${RECAPTCHA_SECRET_KEY-(unset)}
   # @todo the sendgrid values should be removed once the @base-cms/mailer service is created.
   SENDGRID_API_KEY: ${SENDGRID_API_KEY-(unset)}


### PR DESCRIPTION
Relates to: https://github.com/base-cms/base-cms/pull/425

`RECAPTCHA_SITE_KEY` is required, so Docker errors without it.